### PR TITLE
fix papercrop to use turbolinks:load

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,7 @@ gem 'roo', '~> 2.8.0'
 
 gem 'friendly_id', '~> 5.2.4'
 
-gem 'papercrop'
+gem 'papercrop', github: 'agilesix/papercrop', branch: 'turbolink-fix'
 gem 'rails-assets-sticky', source: 'https://rails-assets.org'
 gem 'rails-assets-jquery.scrollTo', source: 'https://rails-assets.org'
 gem "nested_form"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/agilesix/papercrop.git
+  revision: 884d6b6e909a146ac1593efe585e67a497f37432
+  branch: turbolink-fix
+  specs:
+    papercrop (0.3.0)
+      jquery-rails
+      paperclip (>= 3.4)
+      rails (>= 3.1)
+
+GIT
   remote: https://github.com/agilesix/surveymonkey.git
   revision: d21232a99470ae53d3c798796e058de94be9426e
   specs:
@@ -236,10 +246,6 @@ GEM
       mime-types
       mimemagic (~> 0.3.0)
       terrapin (~> 0.6.0)
-    papercrop (0.3.0)
-      jquery-rails
-      paperclip (>= 3.4)
-      rails (>= 3.1)
     pg (1.1.3)
     public_suffix (3.0.3)
     puma (3.12.0)
@@ -431,7 +437,7 @@ DEPENDENCIES
   mini_racer
   nested_form
   paperclip (~> 6.0.0)
-  papercrop
+  papercrop!
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
   rails (~> 5.2.1)


### PR DESCRIPTION
## Description - what does this code do?
Updates the papercrop gem to use our forked version which uses `turbolinks:load` to initialize papercrop.
