### PR TITLE
DM-552: commit to practice full flow

### DIFF
--- a/app/mailers/practice_mailer.rb
+++ b/app/mailers/practice_mailer.rb
@@ -1,0 +1,21 @@
+# Mailer for form emails.
+class PracticeMailer < ApplicationMailer
+  default from: ENV['DO_NOT_REPLY_MAILER_SENDER'] || 'do_not_reply@va.gov'
+  layout 'mailer'
+
+  def commitment_response_email(options = {})
+    @user = options[:user]
+    @practice = options[:practice]
+    subject = "Thank you for committing to implement #{@practice.name}"
+
+    mail(to: @user.email, subject: subject)
+  end
+
+  def support_team_notification_of_commitment(options = {})
+    @user = options[:user]
+    @practice = options[:practice]
+    subject = "There is interest in implementing your practice!"
+
+    mail(to: @practice.support_network_email, subject: subject)
+  end
+end

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -53,6 +53,8 @@ class Practice < ApplicationRecord
   has_many :survey_result_files, dependent: :destroy
   has_many :timelines, dependent: :destroy
   has_many :toolkit_files, dependent: :destroy
+  has_many :user_practices, dependent: :destroy
+  has_many :users, through: :user_practices, dependent: :destroy
   has_many :va_employee_practices, dependent: :destroy
   has_many :va_employees, through: :va_employee_practices
   has_many :va_secretary_priority_practices, dependent: :destroy

--- a/app/models/user_practice.rb
+++ b/app/models/user_practice.rb
@@ -1,0 +1,5 @@
+class UserPractice < ApplicationRecord
+  # used to tell if a user has committed to a practice
+  belongs_to :user
+  belongs_to :practice
+end

--- a/app/views/practice_mailer/commitment_response_email.html.erb
+++ b/app/views/practice_mailer/commitment_response_email.html.erb
@@ -1,0 +1,17 @@
+<h1>Thank you for committing to implement <%= @practice.name %></h1>
+
+<p>The support team has been notified and will be reaching out; expect an email from them soon.</p>
+
+<p>Typically the support team will:<p>
+<ul>
+  <li>review the checklist</li>
+  <li>share the toolkit</li>
+  <li>help your team get started</li>
+  <li>provide support</li>
+  <li>answer questions</li>
+  <li>trouble shoot</li>
+  <li>coordinate feedback</li>
+</ul>
+
+<p>We appreciate your effort to implement this practice in order to improve health outcomes, save lives, and increase
+  veteran and staff satisfaction.</p>

--- a/app/views/practice_mailer/support_team_notification_of_commitment.html.erb
+++ b/app/views/practice_mailer/support_team_notification_of_commitment.html.erb
@@ -1,0 +1,4 @@
+<h1>There is interest in implementing your practice!</h1>
+<p><%= @user.email %> has committed to implementing <%= @practice.name %> on <%= Date.today %>.</p>
+<p>They are looking forward to you reaching out and helping them get started.</p>
+<p>Thank you for your efforts to spread your practice and further improve health outcomes, save lives, and increase veteran and staff satisfaction.</p>

--- a/app/views/practices/committed.html.erb
+++ b/app/views/practices/committed.html.erb
@@ -1,0 +1,23 @@
+<div class="full-view-height">
+  <section class="grid-container x1-5-bottom">
+    <div class="dm-font-color-primary-blue p1-top breadcrumbs dm-font-color-super-violet-ish">
+      <a href="/">Home</a>
+      <span class="x0-5-left x0-5-right">›</span>
+      <span><%= link_to @practice.name, practice_path(@practice) %></span>
+      <span class="x0-5-left x0-5-right">›</span>
+      <span><%= link_to 'Next Steps', practice_next_steps_path(practice_id: @practice) %></span>
+      <span class="x0-5-left x0-5-right">›</span>
+      <span>Confirmation</span>
+    </div>
+  </section>
+
+  <section class="margin-top-7 margin-bottom-6">
+    <div class="grid-container">
+      <%= render "shared/messages" %>
+      <h1 class="font-sans-lg margin-bottom-205">Thank you!</h1>
+      <p class="margin-0 margin-bottom-9">You've completed the checklist for this practice. A member of the practice support team will
+        follow up with you shortly.</p>
+      <%= link_to 'Return to practice', practice_path(@practice), class: 'dm-button-link' %>
+    </div>
+  </section>
+</div>

--- a/app/views/practices/next_steps.html.erb
+++ b/app/views/practices/next_steps.html.erb
@@ -10,6 +10,7 @@
 
 <section class="margin-top-7 margin-bottom-6">
   <div class="grid-container">
+    <%= render "shared/messages" %>
     <h1 class="font-sans-3xl margin-bottom-205">Next Steps</h1>
     <h2 class="margin-0">Build a team and implement this practice</h2>
   </div>
@@ -40,13 +41,13 @@
     <div class="grid-row">
       <div class="tablet:grid-col-3 margin-right-4 margin-bottom-5">
         <a target="_blank"
-          href="mailto:?subject=<%= email_practice_subject(@practice) %>&body=<%= email_practice_body(@practice) %>" class="dm-button-link-secondary">
+           href="mailto:?subject=<%= email_practice_subject(@practice) %>&body=<%= email_practice_body(@practice) %>" class="dm-button-link-secondary">
           Email Summary
         </a>
       </div>
       <div class="tablet:grid-col-3">
         <a target="_blank"
-          href="mailto:?subject=<%= email_checklist_subject(@practice) %>&body=<%= email_checklist_body(@practice) %>"
+           href="mailto:?subject=<%= email_checklist_subject(@practice) %>&body=<%= email_checklist_body(@practice) %>"
            class="dm-button-link-secondary">
           Email Checklist
         </a>
@@ -56,11 +57,15 @@
 </section>
 
 <!-- Checklist -->
-<section class="margin-bottom-6">
-  <div class="grid-container margin-bottom-6 padding-x-9">
-    <h2 class="font-sans-xl margin-bottom-205">Checklist</h2>
-    <button id="print-checklist-button" role="button" class="dm-button-secondary margin-bottom-205">Print Checklist</button>
-    <form class="usa-form-large">
+
+<section>
+  <%= form_for :commit, url: {action: :commit }, method: :post do %>
+    <!--  <form class="usa-form-large" action="<%#= practice_commit_path(practice_id: @practice.slug) %>" method="post">-->
+    <div class="grid-container margin-bottom-6 padding-x-9">
+      <h2 class="font-sans-xl margin-bottom-205">Checklist</h2>
+      <button type="button" id="print-checklist-button" role="button" class="dm-button-secondary margin-bottom-205">Print Checklist
+      </button>
+
       <fieldset class="usa-fieldset">
         <legend class="usa-sr-only">Implementation checklist</legend>
 
@@ -180,18 +185,21 @@
           </div>
         </div>
       </fieldset>
-    </form>
-  </div>
+
+    </div>
+    <div class="dm-background-light-blue">
+      <div class="grid-container padding-y-8 padding-x-9">
+        <p>By choosing to Commit to practice you are:</p>
+        <ul class="margin-bottom-7">
+          <li>Signifying your team's readiness after completing the above checklist.</li>
+          <li>Notifying VA of your plan to implement the practice.</li>
+          <li>Messaging the support team to start working with you to implement the practice.</li>
+        </ul>
+        <button role="button" class="dm-button-primary">Commit to this practice</button>
+      </div>
+    </div>
+  <% end %>
+  <!--  </form>-->
 </section>
 
-<section class="dm-background-light-blue">
-  <div class="grid-container padding-y-8 padding-x-9">
-    <p>By choosing to Commit to practice you are:</p>
-    <ul class="margin-bottom-7">
-      <li>Signifying your team's readiness after completing the above checklist.</li>
-      <li>Notifying VA of your plan to implement the practice.</li>
-      <li>Messaging the support team to start working with you to implement the practice.</li>
-    </ul>
-    <button role="button" class="dm-button-primary">Commit to this practice</button>
-  </div>
-</section>
+

--- a/app/views/shared/_messages.erb
+++ b/app/views/shared/_messages.erb
@@ -7,6 +7,7 @@
 <% end %>
 <% if flash.present? %>
   <% flash.each do |key, value| %>
+
     <% if key == 'notice' then key = 'info' end %>
     <div class="grid-container usa-alert usa-alert--<%= key %> margin-bottom-2">
       <div class="usa-alert__body">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   resources :va_employees
   resources :practices do
     get '/next-steps', action: 'next_steps', as: 'next_steps'
+    get '/committed', action: 'committed', as: 'committed'
+    post '/commit', action: 'commit', as: 'commit'
   end
   resources :badges
   resources :job_positions

--- a/db/migrate/20190517052133_create_user_practices.rb
+++ b/db/migrate/20190517052133_create_user_practices.rb
@@ -1,0 +1,11 @@
+class CreateUserPractices < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_practices do |t|
+      t.belongs_to :user
+      t.belongs_to :practice, foreign_key: true
+      t.boolean :committed
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_06_062319) do
+ActiveRecord::Schema.define(version: 2019_05_17_052133) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -600,6 +600,16 @@ ActiveRecord::Schema.define(version: 2019_05_06_062319) do
     t.index ["practice_id"], name: "index_toolkit_files_on_practice_id"
   end
 
+  create_table "user_practices", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "practice_id"
+    t.boolean "committed"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["practice_id"], name: "index_user_practices_on_practice_id"
+    t.index ["user_id"], name: "index_user_practices_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -739,6 +749,7 @@ ActiveRecord::Schema.define(version: 2019_05_06_062319) do
   add_foreign_key "survey_result_files", "practices"
   add_foreign_key "timelines", "practices"
   add_foreign_key "toolkit_files", "practices"
+  add_foreign_key "user_practices", "practices"
   add_foreign_key "va_employee_practices", "practices"
   add_foreign_key "va_employee_practices", "va_employees"
   add_foreign_key "va_secretary_priority_practices", "practices"

--- a/spec/features/practice_spec.rb
+++ b/spec/features/practice_spec.rb
@@ -231,7 +231,7 @@ describe 'Practices', type: :feature do
       it 'should not render departments if all or none are selected' do
         login_as(@user, :scope => :user, :run_callbacks => false)
         @user_practice.update(published: true, approved: true)
-        
+
         # none
         dp = DepartmentPractice.create!(department: @departments[1], practice: @user_practice)
 
@@ -251,8 +251,48 @@ describe 'Practices', type: :feature do
         expect(page).to have_content(@user_practice.name)
         expect(page).to have_content(@user_practice.initiating_facility.upcase)
         expect(page).to have_current_path(practice_next_steps_path(@user_practice))
-        
+
         expect(page).not_to have_selector('#departments-impacted')
+      end
+    end
+
+    describe 'commit to practice' do
+      it 'should let a user commit to a practice' do
+        login_as(@user, :scope => :user, :run_callbacks => false)
+        @user_practice.update(published: true, approved: true, support_network_email: 'test@va.gov')
+        # Visit an individual Practice that is approved and published
+        visit practice_next_steps_path(practice_id: @user_practice.slug)
+        expect(page).to be_accessible.according_to :wcag2a, :section508
+        expect(page).to have_content(@user_practice.name)
+        expect(page).to have_content(@user_practice.initiating_facility.upcase)
+        expect(page).to have_current_path(practice_next_steps_path(@user_practice))
+
+        click_on('Commit to this practice')
+        expect(page).to have_current_path(practice_committed_path(@user_practice))
+        expect(page).to be_accessible.according_to :wcag2a, :section508
+        expect(page).to have_content('Thank you!')
+        expect(page).to have_content('You\'ve completed the checklist for this practice. A member of the practice support team will follow up with you shortly.')
+      end
+
+      it 'should not let a user commit to a practice' do
+        login_as(@user, :scope => :user, :run_callbacks => false)
+        @user_practice.update(published: true, approved: true, support_network_email: 'test@va.gov')
+        # Visit an individual Practice that is approved and published
+        visit practice_committed_path(practice_id: @user_practice.slug)
+        expect(page).to be_accessible.according_to :wcag2a, :section508
+        expect(page).to have_content('You must commit to this practice first!')
+      end
+
+      it 'should let the user know they already committed to a practice' do
+        login_as(@user, :scope => :user, :run_callbacks => false)
+        @user_practice.update(published: true, approved: true, support_network_email: 'test@va.gov')
+        UserPractice.create!(user:@user, practice:@user_practice, committed: true)
+        # Visit an individual Practice that is approved and published
+        visit practice_next_steps_path(practice_id: @user_practice.slug)
+        expect(page).to be_accessible.according_to :wcag2a, :section508
+        click_on('Commit to this practice')
+        expect(page).to have_current_path(practice_committed_path(@user_practice))
+        expect(page).to have_content("You have already committed to this practice. If you did not receive a follow-up email from the practice support team yet, please contact them at #{@user_practice.support_network_email}")
       end
     end
   end

--- a/spec/models/practice_spec.rb
+++ b/spec/models/practice_spec.rb
@@ -40,6 +40,8 @@ RSpec.describe Practice, type: :model do
     it { should have_many(:survey_result_files) }
     it { should have_many(:timelines) }
     it { should have_many(:toolkit_files) }
+    it { should have_many(:user_practices) }
+    it { should have_many(:users) }
     it { should have_many(:va_employee_practices) }
     it { should have_many(:va_employees) }
     it { should have_many(:va_secretary_priority_practices) }


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-552

## Description - what does this code do?
+ adds the commit to practice flow

## Testing done - how did you test it/steps on how can another person can test it 
1. have data
2. go to a practice
3. click "Next Steps"
4. scroll all the way down to the end of the checklist
5. click "Commit to this practice"
6. end up at the confirmation screen
7. get two emails: one sent to the user and one sent to the support team

## Screenshots, Gifs, Videos from application (if applicable)
![localhost_3200_practices_protocol-guided-rapid-evaluation-of-veterans-experiencing-new-transient-neurological-symptoms-prevent-program_committed](https://user-images.githubusercontent.com/19178435/57912000-1361e900-783e-11e9-84f1-5bc4054d03ef.png)

![Screen Shot 2019-05-17 at 12 52 07 AM](https://user-images.githubusercontent.com/19178435/57912036-2a084000-783e-11e9-9d38-c15a0b162ec6.png)

![Screen Shot 2019-05-17 at 12 54 32 AM](https://user-images.githubusercontent.com/19178435/57912112-5f149280-783e-11e9-9e44-443fab890fe0.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/DDUSxYiD1MaWNrGFmMjY8d8a/Diffusion-Marketplace-Designs?node-id=115%3A0

## Acceptance criteria
“Commit to a Practice” (verbiage tbd) button created

Button sends out email to Practice support network email

Button sends out email verification to person signing up for practice

Verification screen/pop-up for having signed up (Design)--new page

Can hit button any time

## Definition of done
- [x] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs