### PR TITLE
Feedback modal

### DIFF
--- a/app/assets/javascripts/_feedback_survey.js
+++ b/app/assets/javascripts/_feedback_survey.js
@@ -10,16 +10,25 @@
 
         // Get the <span> element that closes the modal
         const $span = $(".close");
+        const $lastEl = $(".last_el");
+        const $firstEl = $(".first_el");
 
         // When the user clicks the button, open the modal
         $feedbackModalTriggers.click(function(e) {
             e.preventDefault();
             modal.style.display = "block";
+            $span.focus();
         });
 
         // When the user clicks on <span> (x), close the modal
         $span.click(function() {
             modal.style.display = "none";
+        });
+
+        $span.on('keypress',function(e) {
+          if(e.which == 13) {
+            modal.style.display = "none";
+          }
         });
 
         // When the user clicks anywhere outside of the modal, close it
@@ -29,6 +38,16 @@
             }
         }
 
+        // When the user shift tabs to the first element in the modal, close it
+
+        $firstEl.on('focus', function(e){
+          modal.style.display = "none";
+        })
+
+        // When the user focuses on the last element in the modal, close it
+        $lastEl.on('focus', function(e){
+          modal.style.display = "none";
+        });
     }
 
     $document.on('turbolinks:load', feedbackSurveyModal);

--- a/app/views/shared/_feedback_survey.html.erb
+++ b/app/views/shared/_feedback_survey.html.erb
@@ -1,11 +1,13 @@
 <div id="feedbackModal" class="modal feedback-modal">
   <div class="modal-content width-tablet">
+    <div class="first_el" tabindex="0" aria-label="closing feedback modal"></div>
     <div class="modal-header">
-      <span class="close">&times;</span>
+      <span class="close" tabindex="0" role="button">&times;</span>
       <h2>We would love to hear from you!</h2>
     </div>
     <div class="modal-body padding-0">
       <script>(function(t,e,s,n){var o,a,c;t.SMCX=t.SMCX||[],e.getElementById(n)||(o=e.getElementsByTagName(s),a=o[o.length-1],c=e.createElement(s),c.type="text/javascript",c.async=!0,c.id=n,c.src=["https:"===location.protocol?"https://":"http://","widget.surveymonkey.com/collect/website/js/tRaiETqnLgj758hTBazgdzyNznGBgxW82akUduzCFQICIDKuFxWJUfJpldznFP6R.js"].join(""),a.parentNode.insertBefore(c,a))})(window,document,"script","smcx-sdk");</script>
     </div>
+    <div class="last_el" tabindex="0" aria-label="closing feedback modal"></div>
   </div>
 </div>

--- a/app/views/shared/_feedback_survey.html.erb
+++ b/app/views/shared/_feedback_survey.html.erb
@@ -1,13 +1,13 @@
 <div id="feedbackModal" class="modal feedback-modal">
   <div class="modal-content width-tablet">
-    <div class="first_el" tabindex="0" aria-label="closing feedback modal"></div>
+    <div class="first_el" tabindex="0" aria-label="Closing feedback form"></div>
     <div class="modal-header">
-      <span class="close" tabindex="0" role="button">&times;</span>
+      <span class="close" tabindex="0" role="button" aria-label="Close feedback form">&times;</span>
       <h2>We would love to hear from you!</h2>
     </div>
     <div class="modal-body padding-0">
       <script>(function(t,e,s,n){var o,a,c;t.SMCX=t.SMCX||[],e.getElementById(n)||(o=e.getElementsByTagName(s),a=o[o.length-1],c=e.createElement(s),c.type="text/javascript",c.async=!0,c.id=n,c.src=["https:"===location.protocol?"https://":"http://","widget.surveymonkey.com/collect/website/js/tRaiETqnLgj758hTBazgdzyNznGBgxW82akUduzCFQICIDKuFxWJUfJpldznFP6R.js"].join(""),a.parentNode.insertBefore(c,a))})(window,document,"script","smcx-sdk");</script>
     </div>
-    <div class="last_el" tabindex="0" aria-label="closing feedback modal"></div>
+    <div class="last_el" tabindex="0" aria-label="Closing feedback form"></div>
   </div>
 </div>


### PR DESCRIPTION
### JIRA issue link
599


## Description - what does this code do?
For modals, they should not allow focus behind the modal. Because of the iframe, its difficult to track where the focus is. To fix this, i placed two empty divs, one at the beginning and one at the end. When these get focused, I close the modal. 

When the modal is launched, i place the focus on the close button so that triggering element isn't focused first. 

I also added keyboard controls for the close button and an aria label for it.


## Testing done - how did you test it/steps on how can another person can test it 


## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs