### PR TITLE
dm-732 Fix devise redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :setup_breadcrumb_navigation
+  before_action :store_user_location!, if: :storable_location?
 
   protected
 
@@ -42,13 +43,26 @@ class ApplicationController < ActionController::Base
         session[:breadcrumbs] << {'display': @practice_partner.name, 'path': practice_partner_path(@practice_partner)}
       end
     end
-
   end
 
   private
 
   def facilities_json
     JSON.parse(File.read("#{Rails.root}/lib/assets/va_gov_facilities_all_response.json"))
+  end
+
+  # Its important that the location is NOT stored if:
+  # - The request method is not GET (non idempotent)
+  # - The request is handled by a Devise controller such as Devise::SessionsController as that could cause an
+  #    infinite redirect loop.
+  # - The request is an Ajax request as this can lead to very unexpected behaviour.
+  def storable_location?
+    request.get? && is_navigational_format? && !devise_controller? && !request.xhr?
+  end
+
+  def store_user_location!
+    # :user is the scope we are authenticating
+    store_location_for(:user, request.fullpath)
   end
 
 end


### PR DESCRIPTION
Fixes devise redirect by saving location on every non-devise, non-
ajax request.

### JIRA issue link
https://agile6.atlassian.net/secure/RapidBoard.jspa?rapidView=22&modal=detail&selectedIssue=DM-732

## What was the issue?
When clicking the login button, on the practice page, it would redirect to the wrong page after logging in. Either the root directory, or the practices search page. Because either no cookie was stored for location, or it only got saved when redirected to login. 

## Description - what does this code do?
Adds a few lines for devise, which saves the user's location on most requests, so that proper information is stored when directing yourself to login.
