### PR TITLE
DM-996 Build Favorites Feature

### DIFF
--- a/app/assets/stylesheets/dm_uswds/theme/_uswds-theme-custom-styles.scss
+++ b/app/assets/stylesheets/dm_uswds/theme/_uswds-theme-custom-styles.scss
@@ -230,3 +230,27 @@ a {
     display: flex;
   }
 }
+
+.favorite-practice-button {
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  text-align: center;
+  background-color: white;
+  padding: 5px;
+  border-radius: 50%;
+}
+
+.highlighted-practice > .favorite-practice-button {
+  top: 2%;
+  right: 2%;
+}
+
+.practice-card-list > .favorite-practice-button {
+  top: 1%;
+  right: 11%;
+}
+
+.text-no-underline {
+  @include u-text('no-underline', !important)
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,6 +3,7 @@ class HomeController < ApplicationController
   def index
     @top_practice = Practice.find_by_highlight true
     @featured_practices = Practice.where featured: true
+    @favorite_practices = current_user&.favorite_practices
 
     @facilities_data = facilities_json['features']
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,7 @@ class HomeController < ApplicationController
   def index
     @top_practice = Practice.find_by_highlight true
     @featured_practices = Practice.where featured: true
-    @favorite_practices = current_user&.favorite_practices
+    @favorite_practices = current_user&.favorite_practices || []
 
     @facilities_data = facilities_json['features']
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,8 @@ class User < ApplicationRecord
 
   has_many :visits, class_name: 'Ahoy::Visit'
 
-  has_many :practices
+  has_many :user_practices
+  has_many :practices, through: :user_practices
 
   has_attached_file :avatar
 
@@ -85,6 +86,14 @@ class User < ApplicationRecord
     return 'User' unless last_name || first_name
 
     "#{first_name} #{last_name}"
+  end
+
+  def favorite_practices
+    user_practices.select(&:favorited).map(&:practice)
+  end
+
+  def favorite_practice_ids
+    user_practices.select(&:favorited).map(&:practice_id)
   end
 
   # Authenticates and signs in the User via LDAP

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -28,7 +28,7 @@
       <% if @top_practice %>
         <div class="margin-top-105">
           <div class="dm-background-white">
-            <div class="grid-row">
+            <div class="grid-row highlighted-practice">
               <% if @top_practice.main_display_image.present? %>
                 <% provide(:top_practice_img_styles, raw("<style>
                   .top-practice-img {

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -28,7 +28,7 @@
       <% if @top_practice %>
         <div class="margin-top-105">
           <div class="dm-background-white">
-            <div class="grid-row highlighted-practice">
+            <div class="grid-row">
               <% if @top_practice.main_display_image.present? %>
                 <% provide(:top_practice_img_styles, raw("<style>
                   .top-practice-img {
@@ -38,14 +38,16 @@
                     height: 100%;
                   }
                 </style>")) %>
-
-                <%= link_to @top_practice, class: 'display-flex grid-col-5', 'aria-label': "Go to #{@top_practice.name}", 'tabindex': '-1', 'aria-hidden': 'true' do %>
-                  <div class="grid-col-12">
+                <div class='display-flex grid-col-5 highlighted-practice'>
+                  <%= link_to @top_practice, class: 'grid-col-12', 'aria-label': "Go to #{@top_practice.name}", 'tabindex': '-1', 'aria-hidden': 'true' do %>
                     <div class="img top-practice-img"></div>
-                  </div>
-                <% end %>
+                  <% end %>
+                  <%= render partial: 'practices/favorite_button', locals: {practice: @top_practice} %>
+                </div>
               <% else %>
-                <div class="grid-col-5"></div>
+                <div class="grid-col-5">
+                  <%= render partial: 'practices/favorite_button', locals: {practice: @top_practice} %>
+                </div>
               <% end %>
               <div class="grid-col-7 padding-x-205 padding-y-4">
                 <div class="grid-row margin-bottom-2">
@@ -78,13 +80,35 @@
       <% end %>
     </section>
 
+    <% if @favorite_practices.any? %>
+      <section class="dm-background-white margin-bottom-105 padding-top-2">
+        <div class="grid-container">
+          <div class="grid-row">
+            <h2 class="text-normal">Favorited Practices</h2>
+          </div>
+          <div class="grid-row grid-gap-lg featured-practices">
+            <% @favorite_practices.each do |p| %>
+              <% if p.present? %>
+                <div class="tablet:grid-col-4 margin-y-105 padding-x-105 practice-card-list">
+                  <%= render partial: 'practices/marketplace_card', locals: {practice: p} %>
+                </div>
+              <% end %>
+            <% end %>
+          </div>
+        </div>
+      </section>
+    <% end %>
+
     <% if @featured_practices.any? %>
       <section class="dm-background-white margin-bottom-105 padding-top-2">
         <div class="grid-container">
-          <div class="grid-row featured-practices">
+          <div class="grid-row">
+            <h2 class="text-normal">Featured Practices</h2>
+          </div>
+          <div class="grid-row grid-gap-lg featured-practices">
             <% @featured_practices.each do |p| %>
               <% if p.present? %>
-                <div class="tablet:grid-col-4 padding-105">
+                <div class="tablet:grid-col-4 margin-y-105 padding-x-105 practice-card-list">
                   <%= render partial: 'practices/marketplace_card', locals: {practice: p} %>
                 </div>
               <% end %>

--- a/app/views/practices/_favorite_button.html.erb
+++ b/app/views/practices/_favorite_button.html.erb
@@ -1,5 +1,5 @@
 <% if current_user %>
-  <%= link_to practice_favorite_path(practice, format: :js), method: :post, remote: true, 'aria-label': "Favorite #{practice.name}", 'tabindex': '-1', 'aria-hidden': 'true', 'class': "favorite-practice-button" do %>
+  <%= link_to practice_favorite_path(practice, format: :js), method: :post, remote: true, 'aria-label': "Favorite #{practice.name}", 'tabindex': '-1', 'aria-hidden': 'true', 'class': "favorite-practice-button", 'id': "favorite-button-#{practice.id}" do %>
     <i class="<% if current_user.favorite_practice_ids.include?(practice.id) %>fas text-secondary<% else %>far text-base<% end %> fa-heart favorite-icon-<%= practice.id %> text-no-underline"></i>
   <% end %>
 <% end %>

--- a/app/views/practices/_favorite_button.html.erb
+++ b/app/views/practices/_favorite_button.html.erb
@@ -1,0 +1,5 @@
+<% if current_user %>
+  <%= link_to practice_favorite_path(practice, format: :js), method: :post, remote: true, 'aria-label': "Favorite #{practice.name}", 'tabindex': '-1', 'aria-hidden': 'true', 'class': "favorite-practice-button" do %>
+    <i class="<% if current_user.favorite_practice_ids.include?(practice.id) %>fas text-secondary<% else %>far text-base<% end %> fa-heart favorite-icon-<%= practice.id %> text-no-underline"></i>
+  <% end %>
+<% end %>

--- a/app/views/practices/_marketplace_card.html.erb
+++ b/app/views/practices/_marketplace_card.html.erb
@@ -9,11 +9,12 @@
   }
 </style>
 <% if practice.main_display_image.present? %>
-  <%= link_to practice, 'aria-label': "Go to #{practice.name}", 'tabindex': '-1', 'aria-hidden': 'true' do %>
+  <%= link_to practice, 'aria-label': "Go to #{practice.name}", 'tabindex': '-1', 'aria-hidden': 'true', 'class': 'marketplace-card-image' do %>
     <div class="img grid-row margin-bottom-2 marketplace-card-header-<%= practice.id %>"></div>
   <% end %>
 <% end %>
-<div class="grid-row margin-bottom-2">
+<%= render partial: 'practices/favorite_button', locals: {practice: practice} %>
+<div class="grid-row margin-bottom-2 <% if !practice.main_display_image.present? %>margin-top-4<% end %>">
   <%= link_to practice do %>
     <h2 class="bold display-inline-block x0 font-sans-lg"><%= practice.tagline %></h2>
   <% end %>

--- a/app/views/practices/_show_authenticated.html.erb
+++ b/app/views/practices/_show_authenticated.html.erb
@@ -86,6 +86,12 @@
               <%= @practice.tagline %>
             </h1>
           <% end %>
+          <% if current_user %>
+            <a href="<%= practice_favorite_path(@practice, format: :js) %>" data-method="post" data-remote="true" rel="nofollow" aria-label="Favorite <%= @practice.name %>" tabindex="-1" aria-hidden="true" class="favorite-practice-link text-no-underline">
+              <i class="<% if current_user.favorite_practice_ids.include?(@practice.id) %>fas text-secondary<% else %>far text-primary<% end %> fa-heart favorite-icon-<%= @practice.id %> text-no-underline"></i>
+              <span class="text-primary text-no-underline padding-left-1 favorite-practice-link-text"><% if current_user.favorite_practice_ids.include?(@practice.id) %>Remove from your favorites<% else %>Add to your favorites<% end %></span>
+            </a>
+          <% end %>
           <p><%= @practice.description %></p>
 
           <div class="grid-row margin-bottom-2">
@@ -122,7 +128,7 @@
 
       <div class="desktop:grid-col-9 grid-col-12 p0 p1-5-right">
         <div class="grid-row">
-          <div class="tablet:grid-col-5 padding-x-1 padding-top-1">
+          <div class="tablet:grid-col-5 padding-x-1 padding-top-1 practice-show-image-column">
             <% if @practice.main_display_image.present? %>
               <%= image_tag @practice.main_display_image.url(:thumb), alt: "#{@practice.name} display image" %>
             <% end %>

--- a/app/views/practices/favorite.js.erb
+++ b/app/views/practices/favorite.js.erb
@@ -1,0 +1,9 @@
+<% if @favorited %>
+  $('.favorite-icon-<%= @practice.id %>').removeClass('far text-base');
+  $('.favorite-icon-<%= @practice.id %>').addClass('fas text-secondary');
+  $('.favorite-practice-link-text').text('Remove from your favorites');
+<% else %>
+  $('.favorite-icon-<%= @practice.id %>').removeClass('fas text-secondary');
+  $('.favorite-icon-<%= @practice.id %>').addClass('far text-base');
+  $('.favorite-practice-link-text').text('Add to your favorites');
+<% end %>

--- a/app/views/practices/index.html.erb
+++ b/app/views/practices/index.html.erb
@@ -37,7 +37,7 @@
       <div class="grid-row grid-gap-lg ">
         <% @practices.each_with_index do |practice, i| %>
           <% index = i + 1 %>
-          <div class="tablet:grid-col-4 flex-column display-flex margin-bottom-8 ">
+          <div class="tablet:grid-col-4 flex-column display-flex margin-y-105 padding-x-105 practice-card-list">
             <%= render partial: 'marketplace_card', locals: {practice: practice} %>
             <div class="marketplace-card-border-bottom margin-top-auto"></div>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     get '/next-steps', action: 'next_steps', as: 'next_steps'
     get '/committed', action: 'committed', as: 'committed'
     post '/commit', action: 'commit', as: 'commit'
+    post '/favorite', action: 'favorite', as: 'favorite'
     member do
       post :highlight
       post :un_highlight

--- a/db/migrate/20190910185301_add_favorite_to_user_practices.rb
+++ b/db/migrate/20190910185301_add_favorite_to_user_practices.rb
@@ -1,0 +1,5 @@
+class AddFavoriteToUserPractices < ActiveRecord::Migration[5.2]
+  def change
+    add_column :user_practices, :favorited, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_08_033821) do
+ActiveRecord::Schema.define(version: 2019_09_10_185301) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -380,32 +380,6 @@ ActiveRecord::Schema.define(version: 2019_09_08_033821) do
     t.index ["practice_id"], name: "index_implementation_timeline_files_on_practice_id"
   end
 
-  create_table "impressions", force: :cascade do |t|
-    t.string "impressionable_type"
-    t.integer "impressionable_id"
-    t.integer "user_id"
-    t.string "controller_name"
-    t.string "action_name"
-    t.string "view_name"
-    t.string "request_hash"
-    t.string "ip_address"
-    t.string "session_hash"
-    t.text "message"
-    t.text "referrer"
-    t.text "params"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["controller_name", "action_name", "ip_address"], name: "controlleraction_ip_index"
-    t.index ["controller_name", "action_name", "request_hash"], name: "controlleraction_request_index"
-    t.index ["controller_name", "action_name", "session_hash"], name: "controlleraction_session_index"
-    t.index ["impressionable_type", "impressionable_id", "ip_address"], name: "poly_ip_index"
-    t.index ["impressionable_type", "impressionable_id", "params"], name: "poly_params_request_index"
-    t.index ["impressionable_type", "impressionable_id", "request_hash"], name: "poly_request_index"
-    t.index ["impressionable_type", "impressionable_id", "session_hash"], name: "poly_session_index"
-    t.index ["impressionable_type", "message", "impressionable_id"], name: "impressionable_type_message_index"
-    t.index ["user_id"], name: "index_impressions_on_user_id"
-  end
-
   create_table "job_position_categories", force: :cascade do |t|
     t.string "name"
     t.string "short_name"
@@ -709,6 +683,7 @@ ActiveRecord::Schema.define(version: 2019_09_08_033821) do
     t.boolean "committed"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "favorited", default: false
     t.index ["practice_id"], name: "index_user_practices_on_practice_id"
     t.index ["user_id"], name: "index_user_practices_on_user_id"
   end

--- a/spec/features/favorite_spec.rb
+++ b/spec/features/favorite_spec.rb
@@ -1,0 +1,112 @@
+require 'rails_helper'
+
+describe 'Favorites', type: :feature, focus: true do
+  before do
+    @user = User.create!(email: 'spongebob.squarepants@bikinibottom.net', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now)
+    @practice1 = Practice.create!(name: 'A public practice', approved: true, published: true, tagline: 'Test tagline', featured: true)
+    @practice2 = Practice.create!(name: 'The Best Practice Ever!', approved: true, published: true, tagline: 'Test tagline', featured: true)
+    @user_practice = UserPractice.create!(user: @user, practice: @practice2, favorited: true)
+  end
+
+  describe 'Home page' do
+    describe 'logged out' do
+      it 'should not show a favorite button' do
+        visit '/'
+        expect(page).not_to have_selector('.favorite-practice-button')
+      end
+    end
+
+    describe 'logged in' do
+      before do
+        login_as(@user, :scope => :user, :run_callbacks => false)
+        visit '/'
+      end
+
+      it 'should show a favorite button' do
+        expect(page).to have_selector('.favorite-practice-button')
+      end
+
+      it 'should allow adding a favorite' do
+        favorite_button = find(:css, "#favorite-button-#{@practice1.id}")
+        favorite_button.click
+        expect(favorite_button).to have_selector('.fas')
+      end
+
+      fit 'should allow removing a favorite' do
+        favorite_button = first(:css, "#favorite-button-#{@practice2.id}")
+        favorite_button.click
+        expect(favorite_button).to have_selector('.far')
+      end
+
+      it 'should have a favorites section' do
+        expect(page).to have_content('Favorited Practices')
+      end
+    end
+  end
+
+  describe 'Practice list page' do
+    describe 'logged out' do
+      it 'should not show a favorite button' do
+        visit '/practices'
+        expect(page).not_to have_selector('.favorite-practice-button')
+      end
+    end
+
+    describe 'logged in' do
+      before do
+        login_as(@user, :scope => :user, :run_callbacks => false)
+        visit '/practices'
+      end
+
+      it 'should show a favorite button' do
+        expect(page).to have_selector('.favorite-practice-button')
+      end
+
+      it 'should allow adding a favorite' do
+        favorite_button = find(:css, "#favorite-button-#{@practice1.id}")
+        favorite_button.click
+        expect(favorite_button).to have_selector('.fas')
+      end
+
+      it 'should allow removing a favorite' do
+        favorite_button = first(:css, "#favorite-button-#{@practice2.id}")
+        favorite_button.click
+        expect(favorite_button).to have_selector('.far')
+      end
+    end
+  end
+
+  describe 'Practice show page' do
+    describe 'logged out' do
+      it 'should not show a favorite link' do
+        visit '/practices/the-best-practice-ever'
+        expect(page).not_to have_content('Add to your favorites')
+      end
+    end
+
+    describe 'logged in' do
+      before do
+        login_as(@user, :scope => :user, :run_callbacks => false)
+      end
+
+      it 'should show a favorite link' do
+        visit '/practices/the-best-practice-ever'
+        expect(page).to have_selector('.favorite-practice-link')
+      end
+
+      it 'should allow adding a favorite' do
+        visit '/practices/a-public-practice'
+        favorite_link = find(:css, '.favorite-practice-link')
+        favorite_link.click
+        expect(favorite_link).to have_content('Remove from your favorites')
+      end
+
+      it 'should allow removing a favorite' do
+        visit '/practices/the-best-practice-ever'
+        favorite_link = find(:css, '.favorite-practice-link')
+        favorite_link.click
+        expect(favorite_link).to have_content('Add to your favorites')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,14 +95,15 @@ RSpec.configure do |config|
 
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
-=begin
+
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
   # aliases for `it`, `describe`, and `context` that include `:focus`
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
   config.filter_run_when_matching :focus
-
+  
+=begin
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-996

## Description - what does this code do?
Adds a favorite feature throughout the site. On the homepage and practice list page, a favorite icon will appear on practice images for logged in users (on the practice detail page it will be a link). Clicking this icon/button with toggle the user's favorite state for the practice. The state of the icon should update asynchronously without a page load to give the user visual confirmation of the change.

## Testing done - how did you test it/steps on how can another person can test it 
Visit homepage while logged in, click heart icon on any practice, heart should become read, and state should be persisted on reload

## Screenshots, Gifs, Videos from application (if applicable)
![Favorites](https://user-images.githubusercontent.com/9121162/65283187-7238b700-daeb-11e9-9d83-72e2cdaffb52.gif)
![Favorites-detail](https://user-images.githubusercontent.com/9121162/65283319-a90ecd00-daeb-11e9-9e76-abd8c4643d77.gif)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
![image](https://user-images.githubusercontent.com/9121162/65283359-c6dc3200-daeb-11e9-9245-4ff5ef6b0b5b.png)
![image](https://user-images.githubusercontent.com/9121162/65283364-ca6fb900-daeb-11e9-9cc2-7833f70c098f.png)

## Acceptance criteria
- [x] Build a “Favorites” section on the homepage
- [ ] Build a “Favorites” Section on the User Profile page (not done because profile work in progress)
- [x] Design “Favorite this practice” functionality for each practice (Star icon, heart icon, etc.)
- [x] Build “Favorite this practice” functionality 

## Definition of done
- [ ] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs