### PR TITLE
DM-1068 Add favorites section to profile

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,6 +17,8 @@ class UsersController < ApplicationController
       { text: 'Profile'}
     ]
     @user = User.find(params[:id])
+    @favorite_practices = @user&.favorite_practices || []
+    @facilities_data = facilities_json['features']
   end
 
   def edit_profile

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
 <div class="x0-top">
-  <section class="usa-section p2-top" style="min-height: calc(100vh - 286px)">
+  <section class="usa-section p2-top padding-bottom-0" style="min-height: calc(100vh - 286px)">
     <div class="grid-container">
       <div class="grid-row grid-gap">
         <div class="usa-layout-docs__sidenav desktop:grid-col-3">
@@ -47,5 +47,23 @@
       </div>
     </div>
   </section>
-</div>
 
+  <% if @favorite_practices.any? %>
+    <section class="dm-background-white margin-bottom-105">
+      <div class="grid-container">
+        <div class="grid-row">
+          <h2 class="profile-h2 font-sans-xl">Favorited Practices</h2>
+        </div>
+        <div class="grid-row grid-gap-lg featured-practices">
+          <% @favorite_practices.each do |p| %>
+            <% if p.present? %>
+              <div class="tablet:grid-col-4 margin-y-105 padding-x-105 practice-card-list">
+                <%= render partial: 'practices/marketplace_card', locals: {practice: p} %>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+    </section>
+  <% end %>
+</div>

--- a/spec/features/favorite_spec.rb
+++ b/spec/features/favorite_spec.rb
@@ -109,4 +109,41 @@ describe 'Favorites', type: :feature do
       end
     end
   end
+
+  describe 'User show page' do
+    describe 'logged out' do
+      before do
+        visit "/users/#{@user.id}"
+      end
+
+      it 'should have a favorites section' do
+        expect(page).to have_content('Favorited Practices')
+      end
+
+      it 'should not show a favorite button' do
+        expect(page).not_to have_selector('.favorite-practice-button')
+      end
+    end
+
+    describe 'logged in' do
+      before do
+        login_as(@user, :scope => :user, :run_callbacks => false)
+        visit "/users/#{@user.id}"
+      end
+
+      it 'should have a favorites section' do
+        expect(page).to have_content('Favorited Practices')
+      end
+
+      it 'should not show a favorite button' do
+        expect(page).to have_selector('.favorite-practice-button')
+      end
+
+      it 'should allow removing a favorite' do
+        favorite_button = first(:css, "#favorite-button-#{@practice2.id}")
+        favorite_button.click
+        expect(favorite_button).to have_selector('.far')
+      end
+    end
+  end
 end

--- a/spec/features/user_profile_spec.rb
+++ b/spec/features/user_profile_spec.rb
@@ -19,7 +19,7 @@ describe 'The user index', type: :feature do
 
     login_as(@user2, scope: :user, run_callbacks: false)
     visit "/users/#{@user.id}"
-    expect(page).to_not have_content('Edit profile')    
+    expect(page).to_not have_content('Edit profile')
   end
 
   it 'should have edit profile button for logged in user' do


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-1068

## Description - what does this code do?
Adds a favorites section to a user's profile

## Testing done - how did you test it/steps on how can another person can test it 
Go to user's profile page, see favorites section

## Screenshots, Gifs, Videos from application (if applicable)
![image](https://user-images.githubusercontent.com/9121162/66245623-eb2b3780-e6c3-11e9-92c1-8dd256b59eab.png)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
https://www.figma.com/file/DDUSxYiD1MaWNrGFmMjY8d8a/Diffusion-Marketplace-Designs?node-id=767%3A1

## Definition of done
- [ ] Unit tests written (if applicable)
- [x] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating JIRA issue
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs