### PR TITLE
DM-1336: Allow edit of adoption # and origin date

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -10,8 +10,12 @@ class PracticesController < ApplicationController
                                            :documentation, :resources, :complexity,
                                            :timeline, :risk_and_mitigation,
                                            :contact, :checklist, :published,
-                                           :publication_validation
-  ]
+                                           :publication_validation]
+  before_action only: [:update] do
+    if date_initiated_params_exist(params[:date_initiated])
+      params[:practice][:date_initiated] = create_date_initiated(params[:date_initiated])
+    end
+  end
 
   # GET /practices
   # GET /practices.json
@@ -380,7 +384,7 @@ class PracticesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def practice_params
-    params.require(:practice).permit(:need_training, :tagline, :process, :it_required, :need_new_license, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :cost_to_implement_aggregate, :sustainability_aggregate, :veteran_satisfaction_aggregate, :difficulty_aggregate,
+    params.require(:practice).permit(:need_training, :tagline, :process, :it_required, :need_new_license, :description, :name, :initiating_facility, :summary, :origin_title, :origin_story, :cost_to_implement_aggregate, :sustainability_aggregate, :veteran_satisfaction_aggregate, :difficulty_aggregate, :date_initiated,
                                      :number_adopted, :number_departments, :number_failed, :implementation_time_estimate, :implementation_time_estimate_description, :implentation_summary, :implentation_fte,
                                      :training_provider, :training_length, :training_test, :training_provider_role, :required_training_summary, :support_network_email,
                                      :main_display_image, :main_display_image_original_w, :main_display_image_original_h, :main_display_image_crop_x, :main_display_image_crop_y, :main_display_image_crop_w, :main_display_image_crop_h,
@@ -465,4 +469,12 @@ class PracticesController < ApplicationController
 
     practices_array.to_json.html_safe
   end
+end
+
+def create_date_initiated (date_initiated)
+  Date.new(date_initiated[:year].to_i, date_initiated[:month].to_i)
+end
+
+def date_initiated_params_exist (date_initiated)
+  date_initiated.present? && !(date_initiated.values.include? nil)
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,6 +3,14 @@ module ApplicationHelper
     date.in_time_zone.strftime "%B %Y"
   end
 
+  def date_get_month(date)
+    date.strftime('%m').to_i
+  end
+
+  def date_get_year(date)
+    date.strftime('%Y').to_i
+  end
+
   def content_type(attachment)
     return 'DOCX' if is_word_doc?(attachment)
     'PDF' if is_pdf?(attachment)

--- a/app/views/practices/overview.html.erb
+++ b/app/views/practices/overview.html.erb
@@ -50,6 +50,24 @@
                 <%= f.select(:initiating_facility, options_for_select(['-Select-'], {selected: '-Select-', disabled: '-Select-'}), {}, {id: 'editor_facility_select', class: 'width-full height-5 usa-select'}) %>
               </div>
             </div>
+            <p class="margin-top-3"><span class="text-bold">Practice date:</span>&nbsp;<span>Select the month and year when this practice was created.</span>
+            <div class="grid-row grid-gap-4">
+              <div>
+                <%= label_tag 'editor_date_intiated_month', 'Month', class: 'usa-label' %>
+                <%= select_month(@practice.date_initiated.present? ? date_get_month(@practice.date_initiated) : nil, {prompt: '-Select-', prefix: 'date_initiated'}, {id: 'editor_date_intiated_month', class: 'width-card-lg height-5 usa-select'}) %>
+              </div>
+              <div class="grid-col-fill">
+                <%= label_tag 'editor_date_intiated_year', 'Year', class: 'usa-label' %>
+                <%= select_year(@practice.date_initiated.present? ? date_get_year(@practice.date_initiated) : nil, {start_year: 1970, end_year: Date.today.year, prompt: '-Select-', prefix: 'date_initiated', default: '-Select-'}, {id: 'editor_date_intiated_year', class: 'width-full height-5 usa-select'}) %>
+              </div>
+            </div>
+            <div class="grid-row grid-gap-4">
+              <div>
+                <%= f.label :number_adopted, 'Practice adoptions:', class: 'usa-label text-bold display-block' %>
+                <span>Type the total number of times your practice has been adopted by other facilities.</span>
+                <%= f.number_field :number_adopted, class: "grid-col-3 usa-input", min: 0 %>
+              </div>
+            </div>
             <div>
               <%= f.label :summary, 'Practice summary: ', class: 'usa-label text-bold display-block' %>
               <span>Type a brief summary of your practice’s mission.</span>&nbsp;<span id="practice-editor-summary-character-counter" class="text-base-light">(0/400 characters)</span>

--- a/spec/features/practice_editor/overview_spec.rb
+++ b/spec/features/practice_editor/overview_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'Practice editor', type: :feature, js: true do
     before do
         @admin = User.create!(email: 'toshiro.hitsugaya@soulsociety.com', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
-        @practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline')
+        @practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', number_adopted: 1, date_initiated: Date.new(2011, 12, 31))
         @practice_partner = PracticePartner.create!(name: 'Diffusion of Excellence', short_name: '', description: 'The Diffusion of Excellence Initiative', icon: 'fas fa-heart', color: '#E4A002')
         @admin.add_role(User::USER_ROLES[0].to_sym)
     end
@@ -20,6 +20,9 @@ describe 'Practice editor', type: :feature, js: true do
             expect(page).to have_content('Overview')
             expect(page).to have_link(href: "/practices/#{@practice.slug}/edit/instructions")
             expect(page).to have_link(href: "/practices/#{@practice.slug}/edit/origin")
+            expect(page).to have_field('Month', with: '12')
+            expect(page).to have_field('Year', with: '2011')
+            expect(page).to have_field('practice_number_adopted', with: '1')
         end
 
         it 'should allow the user to update the data on the page' do
@@ -27,12 +30,18 @@ describe 'Practice editor', type: :feature, js: true do
             fill_in('practice_tagline', with: 'Super duper')
             select('Alabama', :from => 'editor_state_select')
             select('Birmingham VA Medical Center', :from => 'editor_facility_select')
+            select('October', :from => 'editor_date_intiated_month')
+            select('1970', :from => 'editor_date_intiated_year')
+            fill_in('practice_number_adopted', with: '15')
             fill_in('practice_summary', with: 'This is the most super practice ever made')
             find('#practice_partner_1_label').click
             @save_button.click
             expect(page).to have_field('practice_name', with: 'A super practice')
             expect(page).to have_field('practice_tagline', with: 'Super duper')
             expect(page).to have_field('practice_summary', with: 'This is the most super practice ever made')
+            expect(page).to have_field('Month', with: '10')
+            expect(page).to have_field('Year', with: '1970')
+            expect(page).to have_field('practice_number_adopted', with: '15')
         end
 
         # it 'should show an alert window if no practice partners were chosen' do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe "#date_get_month" do
+    context "when given a date" do
+      it "returns the month of that date as an integer" do
+        mock_date = Date.new(2012, 10, 30)
+        expect(helper.date_get_month(mock_date)).to eq(10)
+      end
+    end
+  end
+
+  describe "#date_get_year" do
+    context "when given a date" do
+      it "returns the year of that date as an integer" do
+        mock_date = Date.new(2012, 10, 30)
+        expect(helper.date_get_year(mock_date)).to eq(2012)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### JIRA issue link
[DM-1336](https://agile6.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=DM&modal=detail&selectedIssue=DM-1336&quickFilter=31)

## Description - what does this code do?
This PR allows any user who can edit a practice page to be able to update the `date_initiated` and `number_adopted` fields of a practice via the edit form.

## Testing done - how did you test it/steps on how can another person can test it 
1. Be logged in as a user that can edit a practice page
2. Go to the "Overview" section of the practice page edit form
3. You should see the new origin date and number of practices adopted fields
4. You should be able to edit those fields
5. Those changes should persist on the DB

## Screenshots, Gifs, Videos from application (if applicable)
<img width="821" alt="Screen Shot 2020-03-02 at 11 20 15 AM" src="https://user-images.githubusercontent.com/20211771/75695301-da352100-5c77-11ea-8c7e-b2a2ea21d658.png">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
[Figma](https://www.figma.com/file/DDUSxYiD1MaWNrGFmMjY8d8a/Diffusion-Marketplace-Designs?node-id=3788%3A2721)

## Acceptance criteria
- [X] Follow [design](https://www.figma.com/file/DDUSxYiD1MaWNrGFmMjY8d8a/Diffusion-Marketplace-Designs?node-id=1745%3A27776)
- [X] Make this in the overview section
- [X] Keep the syntax we have
- [X] Make "Origin Year" and "Number of Adoptions" editable

## Definition of done
- [X] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs