### PR TITLE
DM-1324: [App] Hide Collaborators tab and page

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -317,6 +317,7 @@ class PracticesController < ApplicationController
 
   # /practices/slug/collaborators
   def collaborators
+    redirect_to practice_overview_path(@practice)
   end
 
   # /practices/slug/overview

--- a/app/views/practices/_practice_editor_sidenav.html.erb
+++ b/app/views/practices/_practice_editor_sidenav.html.erb
@@ -5,9 +5,6 @@
                 <%= link_to 'Instructions', practice_instructions_path(@practice), class: 'dm-tab top-tab editor-sidenav-link sidenav-instructions-link' %>
             </li>
             <li class="usa-sidenav__item">
-                <%= link_to 'Collaborators', practice_collaborators_path(@practice), class: 'dm-tab editor-sidenav-link sidenav-collaborators-link' %>
-            </li>
-            <li class="usa-sidenav__item">
                 <%= link_to practice_overview_path(@practice), class: 'width-full dm-tab practice-editor-link text-middle display-inline-block editor-sidenav-link sidenav-overview-link' do %>
                     <i class="fas fa-check-circle font-code-lg display-inline-block text-middle padding-right-105 <%= @practice.name && @practice.tagline && @practice.summary && @practice.practice_partners.any? ? 'green-check' : '' %>"></i>Overview
                 <% end %>

--- a/app/views/practices/instructions.html.erb
+++ b/app/views/practices/instructions.html.erb
@@ -33,7 +33,7 @@
           </div>
       </section>
       <div>
-      <%= link_to practice_collaborators_path(@practice), class: 'usa-button padding-2 editor-continue-link margin-right-1 margin-bottom-5' do %>
+      <%= link_to practice_overview_path(@practice), class: 'usa-button padding-2 editor-continue-link margin-right-1 margin-bottom-5' do %>
         Continue<i class="fas fa-chevron-right fa-sm margin-left-1 text-no-underline"></i>
       <% end %>
       </div>

--- a/app/views/practices/overview.html.erb
+++ b/app/views/practices/overview.html.erb
@@ -90,7 +90,7 @@
           </fieldset>
         <% end %>
         <div class="grid-row margin-bottom-8">
-            <%= link_to practice_collaborators_path(@practice), class: 'usa-button usa-button--outline editor-back-to-link margin-right-1 padding-2 margin-bottom-5 text-no-underline' do %>
+            <%= link_to practice_instructions_path(@practice), class: 'usa-button usa-button--outline editor-back-to-link margin-right-1 padding-2 margin-bottom-5 text-no-underline' do %>
                 <i class="fas fa-chevron-left fa-sm text-no-underline margin-right-1"></i>Back
             <% end %>
             <%= link_to practice_origin_path(@practice), class: 'usa-button padding-2 editor-continue-link margin-right-1 margin-bottom-5' do %>

--- a/spec/features/practice_editor/collaborators_spec.rb
+++ b/spec/features/practice_editor/collaborators_spec.rb
@@ -14,10 +14,16 @@ describe 'Practice editor', type: :feature, js: true do
             expect(page).to be_accessible.according_to :wcag2a, :section508
         end
 
-        it 'should be there' do
-            expect(page).to have_content('Collaborators')
-            expect(page).to have_link(href: "/practices/#{@practice.slug}/edit/instructions")
-            expect(page).to have_link(href: "/practices/#{@practice.slug}/edit/overview")
+        # This redirect is temporary (DM-1324)
+        it 'should redirect to the Overview page' do
+            expect(page).to have_content('Overview')
+            expect(page).not_to have_content('Collaborators')
         end
+
+        # it 'should be there' do
+        #     expect(page).to have_content('Collaborators')
+        #     expect(page).to have_link(href: "/practices/#{@practice.slug}/edit/instructions")
+        #     expect(page).to have_link(href: "/practices/#{@practice.slug}/edit/overview")
+        # end
     end
 end

--- a/spec/features/practice_editor/instructions_spec.rb
+++ b/spec/features/practice_editor/instructions_spec.rb
@@ -19,9 +19,15 @@ describe 'Practice editor', type: :feature, js: true do
             expect(page).to have_link(href: "mailto:marketplace@va.gov")
         end
 
-        it 'should take the user to the collaborators page after clicking the continue button' do
+        it 'should take the user to the overview page after clicking the continue button' do
             find(".editor-continue-link").click
-            expect(page).to have_current_path(practice_collaborators_path(@practice))
+            wait_for_page_load('Overview')
+            expect(page).to have_content('Overview')
+            expect(page).to have_current_path(practice_overview_path(@practice))
         end
+    end
+
+    def wait_for_page_load(title)
+        find('div#overview', text: title)
     end
 end

--- a/spec/features/practice_editor/overview_spec.rb
+++ b/spec/features/practice_editor/overview_spec.rb
@@ -25,6 +25,10 @@ describe 'Practice editor', type: :feature, js: true do
             expect(page).to have_field('practice_number_adopted', with: '1')
         end
 
+        it 'should not have a link to the collaborators page' do
+            expect(page).not_to have_link(href: "/practices/#{@practice.slug}/edit/collaborators")
+        end
+
         it 'should allow the user to update the data on the page' do
             fill_in('practice_name', with: 'A super practice')
             fill_in('practice_tagline', with: 'Super duper')

--- a/spec/features/practice_editor/sidenav_spec.rb
+++ b/spec/features/practice_editor/sidenav_spec.rb
@@ -16,13 +16,17 @@ describe 'Practice editor', type: :feature, js: true do
         end
 
         it 'should be there' do
-            expect(page).to have_css('.usa-sidenav__item', count: 12)
+            expect(page).to have_css('.usa-sidenav__item', count: 11)
+        end
+
+        it 'should not have a link to Collaborators' do
+            expect(page).not_to have_link('Collaborators', href: "/practices/#{@practice.slug}/edit/collaborators")
         end
 
         it 'should navigate the user around the editor when they click on the section names' do
-            find('.sidenav-collaborators-link').click
-            expect(page).to have_content('Collaborators')
-            expect(page).to have_content('Here you can add people at your facility who can help you complete this practice page.')
+            find('.sidenav-overview-link').click
+            expect(page).to have_content('Overview')
+            expect(page).to have_content('Introduce your practice and provide a clear overview to people who may be unfamiliar with it.')
 
             find('.sidenav-documentation-link').click
             expect(page).to have_content('Documentation')


### PR DESCRIPTION
### JIRA issue link
[DM-1324](https://agile6.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=DM&modal=detail&selectedIssue=DM-1324)

## Description - what does this code do?
This PR ensures that all links to the "Collaborators" section are removed or changed in favor of the "Overview"/"Instructions" section. The user will no longer be able to see the "Collaborators" link in the side navigation. The user will also be redirected to the "Overview" edit page if they navigate to `.../practices/:practice_id/edit/collaborators`

## Testing done - how did you test it/steps on how can another person can test it 
- Log in as a user who can edit a practice page
- Navigate to the edit pages
- You should not see the "Collaborators" tab in the side navigation
- When navigating to `.../practices/:practice_id/edit/collaborators`, you should be redirected to `.../practices/:practice_id/edit/overview`
- When clicking the "Continue" button on the "Instructions" page, you should go to the "Overview" section
- When clicking the "Back" button on the "Overview" page, you should go to the "Instructions" section

## Screenshots, Gifs, Videos from application (if applicable)
<img width="175" alt="Screen Shot 2020-03-05 at 4 50 57 PM" src="https://user-images.githubusercontent.com/20211771/76033494-019f1e80-5f02-11ea-802e-bbd0d14c82de.png">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
N/A

## Acceptance criteria
- [X] No "Collaborators" tab in side navigation
- [X] Redirect collaborators url
- [X] Tests are updated

## Definition of done
- [X] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs