### PR TITLE
DM-1338: [App] Move main practice img to Overview

### DIFF
--- a/app/assets/javascripts/practice_editor_overview.es6
+++ b/app/assets/javascripts/practice_editor_overview.es6
@@ -121,12 +121,37 @@
         });
     }
 
+    function removePracticeThumbnail() {
+        let placeholder = $('#practice-thumbnail-placeholder')
+        let thumbnailExists = placeholder.find('img').length
+        let defaultThumbnail = "<div class='bg-base-lightest position-relative radius-md' style='height: 300px; width: 350px;'><i class='fas fa-images fa-4x text-base-lighter no-impact-image'></i></div>"
+
+        $('#practice_delete_main_display_image').click((event) => {
+            if (thumbnailExists) {
+                placeholder.empty()
+                placeholder.append(defaultThumbnail)
+            }
+        })
+    }
+
+    function clearPracticeThumbnailRemoval() {
+        let thumbnailFileUpload = $('#practice_main_display_image')
+        let thumbnailRemoveInput = $('#practice_delete_main_display_image')
+
+        // triggers only on successful image upload
+        thumbnailFileUpload.on('change', (event) => {
+            thumbnailRemoveInput.val('false')
+        })
+    }
+
     function loadPracticeEditorFunctions() {
         getFacilitiesByState();
         countCharsOnPageLoad();
         maxCharacters();
         uncheckAllPartnerBoxes();
         uncheckNoneOptionIfAnotherOptionIsChecked();
+        removePracticeThumbnail();
+        clearPracticeThumbnailRemoval()
 
         if(selectedFacility) {
             selectFacility();

--- a/app/assets/stylesheets/dm/pages/_practice.scss
+++ b/app/assets/stylesheets/dm/pages/_practice.scss
@@ -478,6 +478,26 @@
   }
 }
 
+.remove-main-display-image-link {
+  margin-top: 6px;
+  margin-bottom: 24px;
+  color: $dm-color-high-red;
+  text-decoration: underline;
+
+  &:hover {
+    color: #b51d09; /* TODO: check if this is needed */
+  }
+}
+
+.upload-main-display-image-link {
+  color: $dm-color-primary-blue;
+  text-decoration: underline;
+
+  &:hover {
+    color: #162E51; /* TODO: check if this is needed */
+  }
+}
+
 .add-required-staff-link {
   margin-top: 24px !important;
 }
@@ -715,4 +735,9 @@
   width: 65px;
   height: 65px;
   object-fit: cover;
+}
+
+.thumbnail-upload-text {
+  font-size: 16.96px;
+  line-height: 26px;
 }

--- a/app/assets/stylesheets/dm/pages/_practice.scss
+++ b/app/assets/stylesheets/dm/pages/_practice.scss
@@ -486,6 +486,7 @@
 
   &:hover {
     color: #B50909;
+    cursor: pointer;
   }
 }
 
@@ -495,6 +496,7 @@
 
   &:hover {
     color: $dm-color-primary-dark-blue;
+    cursor: pointer;
   }
 }
 

--- a/app/assets/stylesheets/dm/pages/_practice.scss
+++ b/app/assets/stylesheets/dm/pages/_practice.scss
@@ -485,7 +485,7 @@
   text-decoration: underline;
 
   &:hover {
-    color: #b51d09; /* TODO: check if this is needed */
+    color: #B50909;
   }
 }
 
@@ -494,7 +494,7 @@
   text-decoration: underline;
 
   &:hover {
-    color: #162E51; /* TODO: check if this is needed */
+    color: $dm-color-primary-dark-blue;
   }
 }
 

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -163,38 +163,14 @@ class PracticesController < ApplicationController
           end
         end
       end
-
-
-      # Change impact photo to main display image
-      @practice.impact_photos.each do |ip|
-        if ip.is_main_display_image
-          
-          selected_impact_photo = @practice.impact_photos.find(ip[:id]).attachment
-          @practice.update_attributes(main_display_image: selected_impact_photo)
-          
+      
+      # Remove main display image
+      if params[:practice][:delete_main_display_image].present?
+        if params[:practice][:delete_main_display_image] == 'true'
+          @practice.update_attributes(main_display_image: nil)
         end
       end
-      
-      if @practice.impact_photos.where(is_main_display_image: true).empty? || @practice.impact_photos.empty?
-        @practice.update_attributes(main_display_image: nil)
-      end
 
-      if @practice.main_display_image.blank? && @practice.impact_photos.any?
-        impact_photo = @practice.impact_photos.find_by(position: 1)
-        @practice.update_attributes(main_display_image: impact_photo.attachment)
-        impact_photo.update_attributes(is_main_display_image: true)
-      end
-
-
-      # Aurora's code
-      # if params[:practice][:impact_photos_attributes].present?
-      #   save_as_main_display_image = strong_params[:impact_photos_attributes].to_hash.find{|key, hash| hash["save_as_main_display_image"] == 'on'}
-      #   if save_as_main_display_image.present?
-      #     selected_impact_photo = @practice.impact_photos.find(strong_params[:save_as_main_display_image][:id])
-      #     @practice.update_attributes(main_display_image: selected_impact_photo.attachment) if selected_impact_photo.present?
-      #   end
-      # end
-      
       partner_keys.each do |key|
         next if @practice.practice_partners.ids.include? key.to_i
 

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -13,6 +13,7 @@ class Practice < ApplicationRecord
   attr_accessor :last_month_commits
   attr_accessor :two_months_ago_commits
   attr_accessor :three_months_ago_commits
+  attr_accessor :delete_main_display_image
 
   def views
     Ahoy::Event.where_props(practice_id: id).count

--- a/app/views/practices/impact.html.erb
+++ b/app/views/practices/impact.html.erb
@@ -67,15 +67,6 @@
                                                     </div>
                                                 </div>
                                             </div>
-
-                                            <div class='usa-radio margin-top-3'>
-                                                <%= ip.radio_button('is_main_display_image', true, class: "usa-radio__input impact-radio", checked: "#{ip.object.is_main_display_image == true ? 'checked' : false }") %>
-                                                <%= ip.label 'is_main_display_image_true', 'Selected as thumbnail image', class: 'usa-radio__label display-inline-block' %>
-
-                                                <%= ip.radio_button('is_main_display_image', false, class: "usa-radio__input false hidden-radio", checked: false) %>
-                                                <%= ip.label 'is_main_display_image_true', 'Selected as thumbnail image', class: 'usa-radio__label hidden-radio' %>
-                                            </div>
-                                
                                             <div class="grid-row width-full">
                                                 <div class="grid-col-11">
                                                     <%= ip.label :description, 'Caption:', class: 'usa-label text-bold display-inline-block' %>&nbsp;<span>Share how your practice is making a real-life impact.</span>&nbsp;<span class="text-base-light impact-photo-caption-character-count" <% if photo_id.present? %>id="impact_photo_<%= photo_id %>_caption_character_count"<% end %>>(0/300 characters)</span>

--- a/app/views/practices/overview.html.erb
+++ b/app/views/practices/overview.html.erb
@@ -39,6 +39,37 @@
               <%= f.text_area :tagline, class: "usa-textarea #{ @practice.errors[:tagline].any? ? 'usa-input--error' : '' } display-block practice-editor-tagline-textarea" %>
               <p class="usa-error-message <%= @practice.errors[:tagline].any? ? 'fas fa-exclamation-circle fon' : 'display-none' %>">&nbsp;<span class="font-family-sans"><%= show_errors(@practice, :tagline) %></span></p>
             </div>
+            <p class="margin-top-3"><span class="text-bold">Practice thumbnail:</span>&nbsp;</p>
+            <div class="grid-row margin-top-1">
+              <div class="grid-col-6">
+                <% if @practice.main_display_image.present? %>
+                  <%= image_tag @practice.main_display_image.url, alt: "practice thumbnail for #{@practice.name}", class: 'height-mobile practice-editor-impact-photo radius-md' %>
+                <% else %>
+                  <div class="bg-base-lightest position-relative radius-md" style="height: 300px; width: 350px;">
+                    <i class="fas fa-images fa-4x text-base-lighter no-impact-image"></i>
+                  </div>
+                <% end %>
+              </div>
+              <div class="grid-col-6">
+                <div class="margin-bottom-205 margin-left-3 margin-top-1">
+                  <p class="thumbnail-upload-text">Upload a clear photo that will be shown as the representative image for this practice. You can upload a .jpg, .jpeg, or .png file and the size limit is 1GB.</p>
+                </div>
+                <div class="grid-row margin-left-3 flex-align-start">
+                  <div class="grid-col-fill">
+                    <div class="">
+                      <%= f.file_field :main_display_image, class: "hidden-upload hidden-impact-photo-upload", accept: 'image/*' %>
+                      <%= f.label :main_display_image, 'Upload new photo', class: "upload-main-display-image-link" %>
+                    </div>
+                    <% if @practice.main_display_image.present? %>
+                      <div>
+                        <%= f.check_box :delete_main_display_image, { class: "usa-checkbox__input"}, 'true', 'false' %>
+                        <%= f.label :delete_main_display_image, 'Remove photo', class: "usa-checkbox__label display-inline-block text-secondary remove-main-display-image-link" %>
+                      </div>
+                    <% end %>
+                  </div>
+                </div>
+              </div>
+            </div>
             <p class="margin-top-3"><span class="text-bold">Practice origin:</span>&nbsp;<span>Select the state and facility where this practice originated</span>
             <div class="grid-row grid-gap-4">
               <div>

--- a/app/views/practices/overview.html.erb
+++ b/app/views/practices/overview.html.erb
@@ -41,9 +41,9 @@
             </div>
             <p class="margin-top-3"><span class="text-bold">Practice thumbnail:</span>&nbsp;</p>
             <div class="grid-row margin-top-1">
-              <div class="grid-col-6">
+              <div id="practice-thumbnail-placeholder" class="grid-col-6">
                 <% if @practice.main_display_image.present? %>
-                  <%= image_tag @practice.main_display_image.url, alt: "practice thumbnail for #{@practice.name}", class: 'height-mobile practice-editor-impact-photo radius-md' %>
+                  <%= image_tag @practice.main_display_image_s3_presigned_url, alt: "practice thumbnail for #{@practice.name}", class: 'height-mobile practice-editor-impact-photo radius-md' %>
                 <% else %>
                   <div class="bg-base-lightest position-relative radius-md" style="height: 300px; width: 350px;">
                     <i class="fas fa-images fa-4x text-base-lighter no-impact-image"></i>
@@ -62,8 +62,8 @@
                     </div>
                     <% if @practice.main_display_image.present? %>
                       <div>
-                        <%= f.check_box :delete_main_display_image, { class: "usa-checkbox__input"}, 'true', 'false' %>
-                        <%= f.label :delete_main_display_image, 'Remove photo', class: "usa-checkbox__label display-inline-block text-secondary remove-main-display-image-link" %>
+                        <%= f.check_box :delete_main_display_image, { class: "usa-checkbox__input"}, 'true', 'true' %>
+                        <%= f.label :delete_main_display_image, 'Remove photo', class: "display-inline-block text-secondary remove-main-display-image-link"%>
                       </div>
                     <% end %>
                   </div>

--- a/spec/features/practice_editor/impact_spec.rb
+++ b/spec/features/practice_editor/impact_spec.rb
@@ -27,7 +27,6 @@ describe 'Practice editor', type: :feature, js: true do
         
         def fill_in_impact_photo_fields
             attach_file('Upload photo', @image_path)
-            find('.usa-radio__label').click
             all('.practice-editor-image-caption').first.set(@photo_caption)
         end
 
@@ -48,7 +47,6 @@ describe 'Practice editor', type: :feature, js: true do
                 expect(page).to have_content('Practice was successfully updated')
                 expect(page).to have_field('practice[impact_photos_attributes][0][description]', with: @photo_caption)
                 expect(page).to have_selector('.practice-editor-impact-photo')
-                expect(find_field('practice[impact_photos_attributes][0][is_main_display_image]')).to be_checked
             end
 
             it 'should allow the user to add multiple impact photos' do
@@ -62,7 +60,6 @@ describe 'Practice editor', type: :feature, js: true do
                 expect(page).to have_selector('.practice-editor-impact-photo', count: 2)
                 expect(page).to have_field('practice[impact_photos_attributes][0][description]', with: @photo_caption)
                 expect(page).to have_field('practice[impact_photos_attributes][1][description]', with: 'This is the second cutest charmander image ever')
-                expect(find_field('practice[impact_photos_attributes][0][is_main_display_image]')).to be_checked
             end
 
             it 'should allow the user to delete impact photos' do

--- a/spec/features/practice_editor/overview_spec.rb
+++ b/spec/features/practice_editor/overview_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'Practice editor', type: :feature, js: true do
     before do
         @admin = User.create!(email: 'toshiro.hitsugaya@soulsociety.com', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
-        @practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', number_adopted: 1, date_initiated: Date.new(2011, 12, 31))
+        @practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', number_adopted: 1, date_initiated: Date.new(2011, 12, 31), main_display_image: sample_file())
         @practice_partner = PracticePartner.create!(name: 'Diffusion of Excellence', short_name: '', description: 'The Diffusion of Excellence Initiative', icon: 'fas fa-heart', color: '#E4A002')
         @admin.add_role(User::USER_ROLES[0].to_sym)
     end
@@ -23,6 +23,9 @@ describe 'Practice editor', type: :feature, js: true do
             expect(page).to have_field('Month', with: '12')
             expect(page).to have_field('Year', with: '2011')
             expect(page).to have_field('practice_number_adopted', with: '1')
+            expect(page).to have_css("img[src*='SpongeBob.png']")
+            expect(page).to have_content('Upload new photo')
+            expect(page).to have_content('Remove photo')
         end
 
         it 'should not have a link to the collaborators page' do
@@ -39,6 +42,7 @@ describe 'Practice editor', type: :feature, js: true do
             fill_in('practice_number_adopted', with: '15')
             fill_in('practice_summary', with: 'This is the most super practice ever made')
             find('#practice_partner_1_label').click
+            check('practice_delete_main_display_image', allow_label_click: true)
             @save_button.click
             expect(page).to have_field('practice_name', with: 'A super practice')
             expect(page).to have_field('practice_tagline', with: 'Super duper')
@@ -46,6 +50,18 @@ describe 'Practice editor', type: :feature, js: true do
             expect(page).to have_field('Month', with: '10')
             expect(page).to have_field('Year', with: '1970')
             expect(page).to have_field('practice_number_adopted', with: '15')
+            expect(page).not_to have_css("img[src*='SpongeBob.png']")
+            expect(page).not_to have_content('Remove photo')
+        end
+
+        it 'should allow the user to upload a new practice thumbnail' do
+            attach_file('practice_main_display_image', File.absolute_path('./spec/fixtures/SpongeBob.png'))
+            expect(page).to have_css("img[src*='SpongeBob.png']")
+            expect(page).to have_content('Upload new photo')
+        end
+
+        def sample_file(filename = 'SpongeBob.png')
+            File.new("spec/fixtures/#{filename}")
         end
 
         # it 'should show an alert window if no practice partners were chosen' do


### PR DESCRIPTION
### JIRA issue link
[DM-1338](https://agile6.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=DM&modal=detail&selectedIssue=DM-1338&quickFilter=31) + subtasks: [DM-1375](https://agile6.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=DM&modal=detail&selectedIssue=DM-1375&quickFilter=31), [DM-1376](https://agile6.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=DM&modal=detail&selectedIssue=DM-1376&quickFilter=31), [DM-1414](https://agile6.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=DM&modal=detail&selectedIssue=DM-1414&quickFilter=31)

## Description - what does this code do?
This PR moves the ability to edit a practice's thumbnail from the "Impact" section to the "Overview" section.

## Testing done - how did you test it/steps on how can another person can test it 
- Log in as a user that can edit a practice
- Click edit and go to the "Overview" section
- You should be able to upload and save a new "Practice Thumbnail"
- You should be able to delete the "Practice Thumbnail" image

## Screenshots, Gifs, Videos from application (if applicable)
<img width="519" alt="Screen Shot 2020-03-06 at 2 33 53 PM" src="https://user-images.githubusercontent.com/20211771/76121107-851b4700-5fb8-11ea-807a-855790e10b4c.png">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
[Figma](https://www.figma.com/file/DDUSxYiD1MaWNrGFmMjY8d8a/Diffusion-Marketplace-Designs?node-id=3788%3A2721)
[Discussion w/ Becca](https://agile6.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=DM&modal=detail&selectedIssue=DM-1413&quickFilter=31)

## Acceptance criteria
- [X] When image is uploaded it is the practice’s main image
- [X] Displays on Search and home pages

## Definition of done
- [X] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs