### PR TITLE
DM-DEVOPS: silence credentials key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY . .
 
 RUN rm -rf config/credentials.yml.enc
 RUN rm -rf config/master.key
-RUN EDITOR="vim --wait" bundle exec rails credentials:edit
+RUN EDITOR="vim --wait" bundle exec rails credentials:edit > /dev/null 2>&1
 
 RUN DB_ADAPTER=nulldb RAILS_ENV=production SES_SMTP_USERNAME=diffusion_marketplace SES_SMTP_PASSWORD=diffusion_marketplace bundle exec rails assets:precompile HOSTNAME=diffusion-marketplace.va.gov
 EXPOSE 3000


### PR DESCRIPTION
makes it so the credentials key does not show in the console while building.