### PR TITLE
DM-1348: [DM-1462] Implement cropper on origin pg

### DIFF
--- a/app/assets/javascripts/_cropper.es6
+++ b/app/assets/javascripts/_cropper.es6
@@ -13,8 +13,12 @@
       alt: 'temporary practice thumbnail'
     },
     contact: {
-      class: 'va-employee-img',
+      class: 'headshot-img',
       alt: 'temporary practice contact avatar'
+    },
+    origin: {
+      class: 'headshot-img',
+      alt: 'temporary practice creator avatar'
     }
   }
 

--- a/app/assets/stylesheets/dm/pages/_practice.scss
+++ b/app/assets/stylesheets/dm/pages/_practice.scss
@@ -419,13 +419,13 @@
   font-size: 22px;
 }
 
-.impact-trash-container, .origin-trash-container, .documentation-trash-container,
-.risk-miti-trash-container, .va-employee-trash-container, .permission-trash-container, .resource-trash-container {
+.impact-trash-container, .documentation-trash-container, .trash-container,
+.risk-miti-trash-container, .permission-trash-container, .resource-trash-container {
   align-self: flex-end;
   text-align: center;
 }
 
-.va-employee-trash-container {
+.trash-container {
   text-align: right;
   padding-right: 0.2rem;
 }
@@ -564,30 +564,16 @@
   margin-top: 0 !important;
 }
 
-.impact-p, .va-employee-headshot-p, .practice-creator-headshot-p {
-  margin-top: 24px;
+.impact-p, .headshot-title {
+  margin-top: 1.5rem;
 }
 
-.practice-creator-headshot-container {
-  width: 65px;
-  height: 65px;
-  position: relative;
-}
-
-.va-employee-headshot-filler, .practice-creator-headshot-filler {
+.headshot-filler {
   position: absolute;
   bottom: 0;
   left: 50%;
   -webkit-transform: translateX(-50%);
   transform: translateX(-50%);
-}
-
-.practice-creator-headshot-col {
-  margin-right: 24px;
-}
-
-.add-va-employee-headshot-label, .add-practice-creator-headshot-label {
-  margin-top: 12px !important;
 }
 
 .practice-editor-origin-ul, .practice-editor-timeline-ul, .practice-editor-risk-mitigation-ul, .practice-editor-contact-ul,
@@ -746,21 +732,15 @@
   width: 1px;
 }
 
-.va-employee-headshot-col {
+.headshot-col {
   max-width: 8.9375rem !important;
 }
 
-.practice-creator-avatar {
-  width: 65px;
-  height: 65px;
-  object-fit: cover;
-}
-
-.va-employee-img {
+.headshot-img {
   min-height: 8.9375rem !important;
 }
 
-.va-employee-headshot-container {
+.headshot-container {
   min-height: 8.9375rem !important;
   text-align: center;
 }

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -190,6 +190,20 @@ class PracticesController < ApplicationController
         end
       end
 
+      # Crop practice creator avatar
+      if params[:practice][:practice_creators_attributes].present?
+        params[:practice][:practice_creators_attributes].each do |key, pc|
+          if pc[:crop_x].present? && pc[:crop_y].present? && pc[:crop_w].present? && pc[:crop_h].present? && pc[:id].present? && pc[:_destroy] == 'false'
+            creator = @practice.practice_creators.find(pc[:id])
+            creator.crop_x = pc[:crop_x]
+            creator.crop_y = pc[:crop_y]
+            creator.crop_w = pc[:crop_w]
+            creator.crop_h = pc[:crop_h]
+            creator.avatar.reprocess!
+          end
+        end
+      end
+
       partner_keys.each do |key|
         next if @practice.practice_partners.ids.include? key.to_i
 
@@ -397,7 +411,7 @@ class PracticesController < ApplicationController
                                      timelines_attributes: [:id, :description, :timeline, :_destroy, :position, milestones_attributes: [:id, :description, :_destroy]],
                                      va_employees_attributes: [:id, :name, :role, :position, :_destroy, :avatar, :crop_x, :crop_y, :crop_w, :crop_h, :delete_avatar],
                                      additional_staffs_attributes: [:id, :_destroy, :title, :hours_per_week, :duration_in_weeks, :permanent],
-                                     additional_resources_attributes: [:id, :_destroy, :name, :position, :description], required_staff_trainings_attributes: [:id, :_destroy, :title, :description], practice_creators_attributes: [:id, :_destroy, :name, :role, :avatar, :position],
+                                     additional_resources_attributes: [:id, :_destroy, :name, :position, :description], required_staff_trainings_attributes: [:id, :_destroy, :title, :description], practice_creators_attributes: [:id, :_destroy, :name, :role, :avatar, :position, :delete_avatar, :crop_x, :crop_y, :crop_w, :crop_h],
                                      publications_attributes: [:id, :_destroy, :title, :link, :position], additional_documents_attributes: [:id, :_destroy, :attachment, :title, :position], practice_permissions_attributes: [:id, :_destroy, :position, :name, :description])
   end
 

--- a/app/models/practice_creator.rb
+++ b/app/models/practice_creator.rb
@@ -1,15 +1,28 @@
 class PracticeCreator < ApplicationRecord
   belongs_to :practice
   belongs_to :user, optional: true
+  after_create :process_crop
 
   acts_as_list scope: :practice
 
   # has_one :user, optional: true
-  has_attached_file :avatar
+  has_attached_file :avatar, styles: { thumb: '200x200>' }, :processors => [:cropper]
 
   attr_accessor :delete_avatar
+  attr_accessor :crop_x, :crop_y, :crop_w, :crop_h
 
   validates_attachment_content_type :avatar, content_type: %r{\Aimage/.*\z}
+
+  def process_crop
+    # using `self` here to circumvent future rubocop offenses
+    if @crop_w.present? && @crop_h.present? && @crop_x.present? && @crop_y.present? && self.avatar.present?
+      self.crop_x = @crop_x
+      self.crop_y = @crop_y
+      self.crop_w = @crop_w
+      self.crop_h = @crop_h
+      self.avatar.reprocess!
+    end
+  end
 
   def avatar_s3_presigned_url(style = nil)
     object_presigned_url(avatar, style)

--- a/app/views/practices/contact.html.erb
+++ b/app/views/practices/contact.html.erb
@@ -59,21 +59,21 @@
                                         <%= vae.text_field :role, class: 'usa-input practice-input width-tablet va-employee-role', 'counter-id': "va_employee_#{vae_id}_role" %>
                                     </div>
 
-                                    <p class="text-bold va-employee-headshot-p margin-bottom-05">Headshot&nbsp;<span class="text-base">(optional)</span></p>
+                                    <p class="text-bold headshot-title margin-bottom-05">Headshot&nbsp;<span class="text-base">(optional)</span></p>
 
                                     <div class="grid-row">
-                                        <div class="grid-col-3 va-employee-headshot-col margin-top-105 margin-right-3">
+                                        <div class="grid-col-3 headshot-col margin-top-105 margin-right-3">
                                             <div class="cropper-images-container" data-type="contact">
                                             <% if vae_avatar.present? %>
-                                                <%= image_tag vae.object.avatar_s3_presigned_url(:original), alt: vae.object.name, class:'cropper-thumbnail-original va-employee-img hidden'%>
-                                                <%= image_tag vae.object.avatar_s3_presigned_url(:thumb), alt: vae.object.name, class:'cropper-thumbnail-modified va-employee-img'%>
+                                                <%= image_tag vae.object.avatar_s3_presigned_url(:original), alt: vae.object.name, class:'cropper-thumbnail-original headshot-img hidden'%>
+                                                <%= image_tag vae.object.avatar_s3_presigned_url(:thumb), alt: vae.object.name, class:'cropper-thumbnail-modified headshot-img'%>
                                             <% end %>
                                             </div>
-                                            <div class="<%= vae_avatar.present? ? 'va-employee-headshot-container bg-base-lightest radius-md cropper-image-placeholder hidden' : 'va-employee-headshot-container bg-base-lightest radius-md cropper-image-placeholder'%>" >
-                                                <i class="fas fa-user fa-7x va-employee-headshot-filler text-base-lighter"></i>
+                                            <div class="<%= vae_avatar.present? ? 'headshot-container bg-base-lightest radius-md cropper-image-placeholder hidden' : 'headshot-container bg-base-lightest radius-md cropper-image-placeholder'%>" >
+                                                <i class="fas fa-user fa-7x headshot-filler text-base-lighter"></i>
                                             </div>
                                         </div>
-                                        <div class="grid-col-8 va-employee-file-col">
+                                        <div class="grid-col-8">
                                             <div class="margin-bottom-2 cropper-upload-text">
                                                 <p>
                                                     Upload a photo that clearly shows a face. You can upload a .jpg, .jpeg, or .png file and the size limit is 1GB.
@@ -94,7 +94,7 @@
                                             <%= vae.label :delete_avatar, 'Remove photo', class: vae_avatar.present? ? 'display-inline-block text-secondary cropper-delete-image-label' : 'display-inline-block text-secondary cropper-delete-image-label hidden'%>
                                             <%= vae.check_box :delete_avatar, { class: vae_avatar.present? ? 'usa-checkbox__input cropper-delete-image' : 'usa-checkbox__input cropper-delete-image hidden'}, 'true', 'false' %>
                                         </div>
-                                        <div class="grid-col-fill flex-align-end va-employee-trash-container">
+                                        <div class="grid-col-fill flex-align-end trash-container">
                                             <%= vae.link_to_remove '', class: "fas fa-trash-alt va-employee-trash text-no-underline", title: 'Remove contact' %>
                                         </div>
                                     </div>

--- a/app/views/practices/origin.html.erb
+++ b/app/views/practices/origin.html.erb
@@ -4,6 +4,7 @@
     <% end %>
     <%= javascript_include_tag 'practice_editor_origin', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag '_practice_editor_utilities', 'data-turbolinks-track': 'reload' %>
+    <%= javascript_include_tag '_cropper', 'data-turbolinks-track': 'reload' %>
 <% end %>
 
 <%= render 'breadcrumbs' %>
@@ -35,10 +36,12 @@
                                     pc_id = pc.object.id
                                     pc_avatar = pc.object.avatar
                                 %>
-                                
                                 <li class="practice-editor-origin-li fields" data-id="<%= pc_id %>">
                                     <%= pc.hidden_field :position, class: 'origin-position' %>
-                                    <div class="origin-container padding-205 border border-width-1px border-base-lighter radius-sm margin-top-3">
+                                    <div class="origin-container padding-205 border border-width-1px border-base-lighter radius-sm margin-top-3 cropper-boundary">
+                                        <% for attribute in [:crop_x, :crop_y, :crop_w, :crop_h] %>
+                                            <%= pc.hidden_field attribute, :id => attribute, :value => nil %>
+                                        <% end %>
                                         <div class="position-relative">
                                             <div class="fas fa-arrows-alt font-sans-lg position-arrows origin-arrows text-base arrows-tooltip">
                                                 <span class="usa-tag tooltip-text">Drag and drop to change order</span>
@@ -51,39 +54,41 @@
                                             <%= pc.text_field :role, class: 'usa-input practice-input width-tablet practice-creator-role', 'counter-id': "practice_creator_#{pc_id}_role" %>
                                         </div>
 
-                                        <p class="text-bold va-employee-headshot-p margin-bottom-05">Headshot</p>
-                                        <p class="width-tablet margin-bottom-05">
-                                            Guidelines for a good headshot will go here. Perhaps a sentence or two that might go to the next line.
-                                        </p>
-
+                                        <p class="text-bold headshot-title margin-bottom-05">Headshot&nbsp;<span class="text-base">(optional)</span></p>
                                         <div class="grid-row">
-                                            <div class="grid-col-auto practice-creator-headshot-col margin-top-105">
-                                                <% if pc_avatar.present? %>
-                                                    <div class="practice-creator-headshot-container">
-                                                        <%= image_tag pc.object.avatar_s3_presigned_url, alt: pc.object.name, class: 'practice-creator-avatar' %>
-                                                    <%#= vae.cropbox :avatar, width: 200, index: vae.index %>
-                                                    </div>
-                                                <% else %>
-                                                    <div class="practice-creator-headshot-container bg-base-lightest radius-md">
-                                                        <i class="fas fa-user fa-3x practice-creator-headshot-filler text-base-lighter"></i>
-                                                    </div>
-                                                <% end %>
-                                            </div>
-                                            <div class="grid-col-10 practice-creator-file-col">
-                                                <div class="display-inline-block">
-                                                    <div class="margin-bottom-1">
-                                                        <%= pc.label :avatar, pc_avatar.present? ? 'Upload new photo' : 'Upload photo', class: "usa-button #{pc_avatar.present? ? 'usa-button--unstyled' : ''} add-practice-creator-headshot-label" %>
-                                                        <%= pc.file_field :avatar, class: 'hidden-upload' %>
-                                                    </div>
+                                            <div class="grid-col-3 headshot-col margin-top-105 margin-right-3">
+                                                <div class="cropper-images-container" data-type="origin">
                                                     <% if pc_avatar.present? %>
-                                                      <div>
-                                                        <%= pc.check_box :delete_avatar, { class: 'usa-checkbox__input practice-input delete-avatar-input'}, 'true', 'false' %>
-                                                        <%= pc.label :delete_avatar, 'Remove photo', class: 'usa-checkbox__label display-inline-block text-secondary' %>
-                                                      </div>
+                                                        <%= image_tag pc.object.avatar_s3_presigned_url(:original), alt: pc.object.name, class:'cropper-thumbnail-original headshot-img hidden'%>
+                                                        <%= image_tag pc.object.avatar_s3_presigned_url(:thumb), alt: pc.object.name, class:'cropper-thumbnail-modified headshot-img'%>
                                                     <% end %>
                                                 </div>
+                                                <div class="<%= pc_avatar.present? ? 'headshot-container bg-base-lightest radius-md cropper-image-placeholder hidden' : 'headshot-container bg-base-lightest radius-md cropper-image-placeholder'%>">
+                                                    <i class="fas fa-user fa-7x headshot-filler text-base-lighter"></i>
+                                                </div>
                                             </div>
-                                            <div class="grid-col-fill flex-align-end origin-trash-container">
+                                            <div class="grid-col-8">
+                                                <div class="margin-bottom-2 cropper-upload-text">
+                                                    <p>
+                                                        Upload a photo that clearly shows a face. You can upload a .jpg, .jpeg, or .png file and the size limit is 1GB.
+                                                    </p>
+                                                </div>
+                                                <div class="margin-bottom-2 cropper-editor-text hidden">
+                                                    <p>
+                                                        Please click "Save edits" and then "Save your progress" to save and exit editor.
+                                                    </p>
+                                                </div>
+                                                <a class="usa-button padding-2 cropper-save-edit hidden" aria-controls='photo-save-edit' aria-expanded='false'>Save edits</a>
+                                                <a class="usa-button usa-button--outline padding-2 cropper-cancel-edit hidden" aria-controls='photo-cancel-edit' aria-expanded='false'>Cancel edits</a>
+                                                <a class="<%= pc_avatar.present? ? "usa-button usa-button--outline padding-2 cropper-edit-mode" : "usa-button usa-button--outline padding-2 cropper-edit-mode hidden" %>" aria-controls='photo-crop' aria-expanded='false'>Edit photo</a>
+                                                <div>
+                                                    <%= pc.label :avatar, pc_avatar.present? ? 'Upload new photo' : 'Upload photo', class: pc_avatar.present? ? 'cropper-upload-image-label' : 'cropper-upload-image-label usa-button'%>
+                                                    <%= pc.file_field :avatar, class: "hidden-upload cropper-upload-image", accept: 'image/*' %>
+                                                </div>
+                                                <%= pc.label :delete_avatar, 'Remove photo', class: pc_avatar.present? ? 'display-inline-block text-secondary cropper-delete-image-label' : 'display-inline-block text-secondary cropper-delete-image-label hidden'%>
+                                                <%= pc.check_box :delete_avatar, { class: pc_avatar.present? ? 'usa-checkbox__input cropper-delete-image' : 'usa-checkbox__input cropper-delete-image hidden'}, 'true', 'false' %>
+                                            </div>
+                                            <div class="grid-col-fill flex-align-end trash-container">
                                                 <%= pc.link_to_remove '', class: "fas fa-trash-alt origin-trash text-no-underline", title: 'remove practice creator' %>
                                             </div>
                                         </div>

--- a/spec/features/practice_editor/contact_spec.rb
+++ b/spec/features/practice_editor/contact_spec.rb
@@ -61,7 +61,7 @@ describe 'Practice editor', type: :feature, js: true do
             @save_button.click
 
             expect(page).to have_content('Practice was successfully updated')
-            expect(page).to have_css("img.va-employee-img")
+            expect(page).to have_css("img.headshot-img")
             expect(page).to have_field('Name:', with: @employee_name)
             expect(page).to have_field('Role:', with: @employee_role)
             expect(page).to have_content('Upload new photo')
@@ -83,7 +83,7 @@ describe 'Practice editor', type: :feature, js: true do
             @save_button.click
 
             expect(page).to have_content('Practice was successfully updated')
-            expect(page).to have_css("img.va-employee-img")
+            expect(page).to have_css("img.headshot-img")
             expect(page).to have_field('practice[va_employees_attributes][0][name]', with: @employee_name)
             expect(page).to have_field('practice[va_employees_attributes][0][role]', with: @employee_role)
             expect(page).to have_field('practice[va_employees_attributes][1][name]', with: 'Test name 2')


### PR DESCRIPTION
### JIRA issue link
[DM-1348](https://agile6.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=DM&modal=detail&selectedIssue=DM-1348&quickFilter=31&assignee=5e4d76fe393ea90c94b41b89&assignee=UNASSIGNED_USER_ID): [[DM-1462](https://agile6.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=DM&modal=detail&selectedIssue=DM-1462&quickFilter=31&assignee=5e4d76fe393ea90c94b41b89&assignee=UNASSIGNED_USER_ID)]

## Description - what does this code do?
This PR implements the cropper on "Origin" page of the practice editor for the practice creator avatar.

## Testing done - how did you test it/steps on how can another person can test it 
- Log in as a user with the ability to edit practices
- Go to the "Origin" section of the Practice Editor
- Crop, delete, upload, etc the contact headshot 

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
[Figma](https://www.figma.com/file/DDUSxYiD1MaWNrGFmMjY8d8a/Diffusion-Marketplace-Designs?node-id=1745%3A27776)

## Acceptance criteria
- [X] Doesn’t have to be 508 Compliant
- [X] **“Origin”** and “Contact” headshot photos should be able to crop the photo 
(Contact - completed in a #153 )
- [X] “Practice Image“ in Overview section should be able to crop photo
- [X] Photo ratios are all 1:1
- [X] User can click and drag picture to center themselves/their branding
- [X] User can crop out parts of the photo so that they or their practice image are clear
- [ ] 3rd Party tool jcrop (using jquery-crop)

## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs