### PR TITLE
DM-1566: default adoptions number

### DIFF
--- a/app/views/practices/_show_authenticated.html.erb
+++ b/app/views/practices/_show_authenticated.html.erb
@@ -147,7 +147,7 @@
               <%# <p><%= @practice.number_failed %> <%#unsuccessful</p> %>
               <p class="margin-0 font-sans-xs-2 line-height-sans-505">
                 <% number_adopted = @practice.diffusion_histories.joins(:diffusion_history_statuses).where.not(diffusion_history_statuses: {status: 'Unsuccessful'}).count %>
-                <span><%= number_adopted %></span>
+                <span><%= number_adopted > 0 ? number_adopted : @practice.number_adopted %></span>
                 facilit<%= number_adopted == 1 ? 'y has' : 'ies have' %> adopted this practice</p>
             </div>
           <% else %>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-1613

## Description - what does this code do?
defaults the adoption number to `number_adopted` if they have it already and have not started the adoptions page.
