### PR TITLE
DM-1492: Save practice on publish

### DIFF
--- a/app/assets/javascripts/save-editor-progress.es6
+++ b/app/assets/javascripts/save-editor-progress.es6
@@ -1,5 +1,7 @@
-function validateForm(form) {
-    if (form[0].checkValidity()) {
+function validateForm({form, railsFireEvent}) {
+    if (form[0].checkValidity() && railsFireEvent) {
+        Rails.fire(form[0], 'submit');
+    } else if (form[0].checkValidity() && !railsFireEvent) {
         form.submit();
     } else {
         form[0].reportValidity();
@@ -9,7 +11,7 @@ function validateForm(form) {
 function submitPracticeEditorSaveForm() {
     $(document).on('click', '#practice-editor-save-button', () => {
         let form = $('#form');
-        validateForm(form);
+        validateForm({ form, railsFireEvent: false });
     });
 }
 
@@ -20,13 +22,28 @@ function saveEditorProgressOnContinue() {
 
         form.append(`<input type='hidden' name='next' value=true>`);
 
-        validateForm(form);
+        validateForm({ form, railsFireEvent: false });
+    });
+}
+
+function saveEditorProgressOnPublish() {
+    $(document).on('click', '#publish-practice-button', (event) => {
+        let $form = $('#form');
+        let formAction = $('#publish-practice-button').data('form-action')
+
+        // set the action to `practice_publication_validation_path`
+        $form.attr('action', formAction)
+        $form.attr('data-remote', true)
+        event.preventDefault();
+
+        validateForm({ form: $form, railsFireEvent: true })
     });
 }
 
 function initSaveProgressFunctions() {
     submitPracticeEditorSaveForm();
     saveEditorProgressOnContinue();
+    saveEditorProgressOnPublish();
 }
 
 $(initSaveProgressFunctions());

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -15,6 +15,7 @@ class Practice < ApplicationRecord
   attr_accessor :three_months_ago_commits
   attr_accessor :delete_main_display_image
   attr_accessor :crop_x, :crop_y, :crop_w, :crop_h
+  attr_accessor :practice_partner, :department
 
   # views
   def views

--- a/app/services/save_practice_service.rb
+++ b/app/services/save_practice_service.rb
@@ -1,0 +1,114 @@
+class SavePracticeService
+  include CropperUtils
+
+  def initialize(params)
+    @practice = params[:practice]
+    @practice_params = params[:practice_params]
+    @avatars = ['practice_creators', 'va_employees']
+    @attachments = ['impact_photos', 'additional_documents']
+  end
+
+  def save_practice
+    updated = @practice.update(@practice_params)
+
+    update_practice_partner_practices
+    update_department_practices
+    remove_attachments
+    manipulate_avatars
+    remove_main_display_image
+    crop_main_display_image
+
+    return updated
+  end
+
+  private
+
+  def update_practice_partner_practices
+    practice_partner_params = @practice_params[:practice_partner]
+    practice_partners = @practice.practice_partner_practices
+    if practice_partner_params.present?
+      partner_keys = practice_partner_params.keys
+      partner_keys.each do |key|
+        next if @practice.practice_partners.ids.include? key.to_i
+
+        practice_partners.create practice_partner_id: key.to_i
+      end
+
+      practice_partners.each do |partner|
+        partner.destroy unless partner_keys.include?(partner.practice_partner_id.to_s)
+      end
+    elsif practice_partner_params.blank? && current_endpoint == 'overview'
+      practice_partners.destroy_all
+    end
+  end
+
+  def update_department_practices
+    department_params = @practice_params[:department]
+    practice_departments = @practice.department_practices
+    if department_params.present?
+      dept_keys = department_params.keys
+      dept_keys.each do |key|
+        next if @practice.departments.ids.include? key.to_i
+
+        @practice.department_practices.create department_id: key.to_i
+      end
+
+      practice_departments.each do |department|
+        department.destroy unless dept_keys.include? department.department_id.to_s
+      end
+    elsif department_params.blank? && current_endpoint == 'complexity'
+      practice_departments.destroy_all
+    end
+  end
+
+  def remove_attachments
+    @attachments.each do |attachment|
+      attribute = ("#{attachment}_attributes").to_sym
+
+      if @practice_params[attribute].present?
+        @practice_params[attribute].each do |key, e|
+          if e['delete_attachment'] == 'true'
+            record = @practice.send(attachment).find(e[:id])
+            record.update_attributes(attachment: nil)
+          end
+        end
+      end
+    end
+  end
+
+  def manipulate_avatars
+    @avatars.each do |avatar|
+      attribute = ("#{avatar}_attributes").to_sym
+
+      if @practice_params[attribute].present?
+        @practice_params[attribute].each do |key, e|
+          if e[:_destroy] == 'false' && e[:id].present?
+            record = @practice.send(avatar).find(e[:id])
+
+            # Remove avatar
+            if e['delete_avatar'] == 'true'
+              record.update_attributes(avatar: nil)
+            end
+
+            # Crop avatar
+            if is_cropping?(e)
+              reprocess_avatar(record, e)
+            end
+          end
+        end
+      end
+    end
+  end
+
+  def remove_main_display_image
+    if @practice_params[:delete_main_display_image].present? && @practice_params[:delete_main_display_image] == 'true'
+      @practice.update_attributes(main_display_image: nil)
+    end
+  end
+
+  def crop_main_display_image
+    if is_cropping?(@practice_params)
+      @practice.main_display_image.reprocess!
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -74,7 +74,6 @@
     <%= render 'shared/header' %>
     <%= render 'shared/breadcrumbs' %>
     <main id="main-content" class="<%= params[:controller] %>">
-      <%= render 'practices/publication_validation_modal' %>
       <%= yield %>
     </main>
     <%= render 'shared/footer' %>

--- a/app/views/practices/_practice_editor_sidenav.html.erb
+++ b/app/views/practices/_practice_editor_sidenav.html.erb
@@ -65,9 +65,13 @@
             <%= button_tag 'Save your progress', class: 'usa-button usa-button--outline width-full padding-y-2 margin-top-1', id: 'practice-editor-save-button' %>
           </div>
         <% end %>
-        <% if !@practice.published && params[:action] != 'adoptions' %>
+        <% if !@practice.published %>
           <div class="text-center">
-            <%= button_tag 'Publish practice', class: 'usa-button width-full padding-y-2 margin-top-1', id: 'publish-practice-button', data: { form_action: "#{practice_publication_validation_path(@practice)}.js"}%>
+            <% if params[:action] == 'adoptions' %>
+                <%= link_to 'Publish practice', practice_publication_validation_path(@practice), class: 'usa-button width-full padding-y-2 margin-top-1', id: 'publish-practice-button', method: :patch, remote: true %>
+            <% else %>
+                <%= button_tag 'Publish practice', class: 'usa-button width-full padding-y-2 margin-top-1', id: 'publish-practice-button', data: { form_action: "#{practice_publication_validation_path(@practice)}.js"}%>
+            <% end %>
           </div>
         <% end %>
     </div>

--- a/app/views/practices/_practice_editor_sidenav.html.erb
+++ b/app/views/practices/_practice_editor_sidenav.html.erb
@@ -62,12 +62,12 @@
         </ul>
         <% if params[:action] != 'adoptions' %>
           <div class="text-center">
-              <%= button_tag 'Save your progress', class: 'usa-button usa-button--outline width-full padding-y-2 margin-top-1', id: 'practice-editor-save-button' %>
+            <%= button_tag 'Save your progress', class: 'usa-button usa-button--outline width-full padding-y-2 margin-top-1', id: 'practice-editor-save-button' %>
           </div>
         <% end %>
-        <% unless @practice.published %>
+        <% if !@practice.published && params[:action] != 'adoptions' %>
           <div class="text-center">
-            <%= link_to 'Publish practice', practice_publication_validation_path(@practice), class: 'usa-button width-full padding-y-2 margin-top-1', id: 'publish-practice-button', method: :post, remote: true %>
+            <%= button_tag 'Publish practice', class: 'usa-button width-full padding-y-2 margin-top-1', id: 'publish-practice-button', data: { form_action: "#{practice_publication_validation_path(@practice)}.js"}%>
           </div>
         <% end %>
     </div>

--- a/app/views/practices/publication_validation.js.erb
+++ b/app/views/practices/publication_validation.js.erb
@@ -1,3 +1,5 @@
+$('#practiceEditorPublicationModal').remove();
+$('body').after("<%= escape_javascript(render partial: 'practices/publication_validation_modal', formats: [ :html ]) %>");
 
 $('#practiceEditorPublicationModal').removeClass('publication-modal-hidden');
 

--- a/app/views/practices/publication_validation.js.erb
+++ b/app/views/practices/publication_validation.js.erb
@@ -1,5 +1,5 @@
 $('#practiceEditorPublicationModal').remove();
-$('body').after("<%= escape_javascript(render partial: 'practices/publication_validation_modal', formats: [ :html ]) %>");
+$('#main-content').after("<%= escape_javascript(render partial: 'practices/publication_validation_modal', formats: [ :html ]) %>");
 
 $('#practiceEditorPublicationModal').removeClass('publication-modal-hidden');
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
     get '/edit/origin', action: 'origin', as: 'origin'
     get '/edit/adoptions', action: 'adoptions', as: 'adoptions'
     post '/edit/create_or_update_diffusion_history/', action: 'create_or_update_diffusion_history', as: 'create_or_update_diffusion_history'
-    post '/publication_validation', action: 'publication_validation', as: 'publication_validation'
+    patch '/publication_validation', action: 'publication_validation', as: 'publication_validation'
     get '/published', action: 'published', as: 'published'
     post '/commit', action: 'commit', as: 'commit'
     post '/favorite', action: 'favorite', as: 'favorite'

--- a/spec/features/practice_editor/complexity_spec.rb
+++ b/spec/features/practice_editor/complexity_spec.rb
@@ -85,6 +85,11 @@ describe 'Practice editor', type: :feature, js: true do
             find('.staff-training-description').set(@staff_training_description)
         end
 
+        def check_department_fields
+            find('label[for=practice_department_1]').click
+            find('label[for=practice_department_2]').click
+        end
+
         it 'should allow the user to add an additional staff member and required staff training' do
             fill_in_required_fields
             fill_in_additional_staff_fields
@@ -149,6 +154,15 @@ describe 'Practice editor', type: :feature, js: true do
             expect(page).to have_field('Role duration', with:  nil)
             expect(page).to have_field('Job Title', with: nil)
             expect(page).to have_field('Description', with: nil)
+        end
+
+        it 'should allow the user to add and remove departments' do
+            fill_in_required_fields
+            fill_in_required_staff_training_fields
+            check_department_fields
+            @save_button.click
+            expect(page).to have_checked_field('practice_department_1', visible: false)
+            expect(page).to have_checked_field('practice_department_2', visible: false)
         end
     end
 end

--- a/spec/features/practice_editor/origin_spec.rb
+++ b/spec/features/practice_editor/origin_spec.rb
@@ -105,9 +105,22 @@ describe 'Practice editor', type: :feature, js: true do
 
             find('.origin-trash').click
             @save_button.click
-            
+
             expect(page).to have_field('Name:', with: nil)
             expect(page).to have_field('Role:', with: nil)
+        end
+
+        it 'should allow the user to delete practice creator avatar' do
+            fill_in_origin_story_field
+            fill_in_creator_fields
+            @save_button.click
+            expect(page).to have_css("img[src*='charmander.png']")
+
+
+            find('.cropper-delete-image-label').click
+            @save_button.click
+
+            expect(page).not_to have_css("img[src*='charmander.png']")
         end
 
         it 'should allow the user to crop multiple practice creators -- new and existing' do

--- a/spec/features/practice_editor/overview_spec.rb
+++ b/spec/features/practice_editor/overview_spec.rb
@@ -53,6 +53,7 @@ describe 'Practice editor', type: :feature, js: true do
             expect(page).to have_field('practice_summary', with: 'This is the most super practice ever made')
             expect(page).to have_field('Month', with: '10')
             expect(page).to have_field('Year', with: '1970')
+            expect(page).to have_checked_field('practice_partner_1')
             expect(page).to have_css("img[src*='charmander.png']")
             expect(page).to have_content('Remove photo')
             expect(page).to have_content('Upload new photo')
@@ -61,6 +62,11 @@ describe 'Practice editor', type: :feature, js: true do
             expect(page).to have_no_content('Upload photo')
             expect(page).to have_no_content('Cancel edits')
             expect(page).to have_no_content('Save edits')
+
+            # delete practice thumbnail
+            find('.cropper-delete-image-label').click
+            @save_button.click
+            expect(page).not_to have_css("img[src*='charmander.png']")
         end
 
         it 'should allow the user to edit the practice thumbnail' do

--- a/spec/features/practice_editor/publish_practice_spec.rb
+++ b/spec/features/practice_editor/publish_practice_spec.rb
@@ -24,6 +24,8 @@ describe 'Practice editor', type: :feature, js: true do
       expect(page).to have_field('practice_name', with: 'A public practice')
       expect(all('.partner-input').first).to be_checked
 
+      # go to impact page since publishing on overview with empty required fields results in form warnings
+      visit practice_impact_path(@practice)
       @publish_button.click
       expect(page).to have_content('Cannot publish yet')
       expect(page).to have_content('You must include a practice tagline')
@@ -33,34 +35,31 @@ describe 'Practice editor', type: :feature, js: true do
       expect(page).to have_content('You must include a support network email')
     end
 
-    it 'Should publish the practice if all required fields are met' do
+    it 'Should save and publish the practice if all required fields are met' do
       tagline = 'Super duper'
       initiated_month = 'October'
       initiated_year = '1970'
       summary = 'This is the most super practice ever made'
+
+      visit practice_contact_path(@practice)
+      email = 'test@email.com'
+      fill_in('Email:', with: email)
+      @save_button.click
+      expect(page).to have_field('Email:', with: email)
+
+      visit practice_overview_path(@practice)
       fill_in('practice_tagline', with: tagline)
       select('Alabama', :from => 'editor_state_select')
       select('Birmingham VA Medical Center', :from => 'editor_facility_select')
       select(initiated_month, :from => 'editor_date_intiated_month')
       select(initiated_year, :from => 'editor_date_intiated_year')
       fill_in('Practice summary:', with: summary)
-      @save_button.click
-
-      expect(page).to have_field('practice_tagline', with: tagline)
-      expect(page).to have_field('practice_summary', with: summary)
-      expect(page).to have_field('Month', with: '10')
-      expect(page).to have_field('Year', with: initiated_year)
-      expect(page).to have_field('State', with: 'AL')
-      expect(page).to have_field('Facility', with: '521')
-
-      visit practice_contact_path(@practice)
-      email = 'test@email.com'
-      fill_in('Email:', with: email)
-      @save_button.click
-
-      expect(page).to have_field('Email:', with: email)
 
       @publish_button.click
+      expect(page).to have_content(tagline)
+      expect(page).to have_content(summary)
+      expect(page).to have_content('October 1970')
+      expect(page).to have_content('Birmingham VA Medical Center')
       expect(page).to have_content('A public practice')
       expect(page).to_not have_content('Cannot publish yet')
       expect(page).to have_content("#{@practice.name} has been successfully published to the Diffusion Marketplace")

--- a/spec/services/save_practice_service_spec.rb
+++ b/spec/services/save_practice_service_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+require_relative '../../app/services/save_practice_service.rb'
+
+RSpec.describe SavePracticeService do
+  describe 'when save_practice errors' do
+    before do
+      practice = Practice.create!(name: 'A public practice', tagline: 'Test tagline', initiating_facility: '687HA', date_initiated: Date.new(2011, 12, 31), summary: 'practice summary', support_network_email: 'fake-support-email@example.com')
+      @save_practice = SavePracticeService.new({ practice: practice, practice_params: {}})
+    end
+
+    context 'while update_practice_partner_practices' do
+      it 'returns a StandardError' do
+        allow(@save_practice).to receive(:update_practice_partner_practices).and_raise(StandardError.new('Error!!!'))
+  
+        result = @save_practice.save_practice
+        expect(result.is_a?(StandardError)).to eq true
+        expect(result.message).to eq 'error updating practice partners'
+      end
+    end
+
+    context 'while update_department_practices' do
+      it 'returns a StandardError' do
+        allow(@save_practice).to receive(:update_department_practices).and_raise(StandardError.new('Error!!!'))
+  
+        result = @save_practice.save_practice
+        expect(result.is_a?(StandardError)).to eq true
+        expect(result.message).to eq 'error updating departments'
+      end
+    end
+
+    context 'while remove_attachments' do
+      it 'returns a StandardError' do
+        allow(@save_practice).to receive(:remove_attachments).and_raise(StandardError.new('Error!!!'))
+  
+        result = @save_practice.save_practice
+        expect(result.is_a?(StandardError)).to eq true
+        expect(result.message).to eq 'error removing attachments'
+      end
+    end
+
+    context 'while manipulate_avatars' do
+      it 'returns a StandardError' do
+        allow(@save_practice).to receive(:manipulate_avatars).and_raise(StandardError.new('Error!!!'))
+  
+        result = @save_practice.save_practice        
+        expect(result.is_a?(StandardError)).to eq true
+        expect(result.message).to eq 'error updating avatars'
+      end
+    end
+
+    context 'while remove_main_display_image' do
+      it 'returns a StandardError' do
+        allow(@save_practice).to receive(:remove_main_display_image).and_raise(StandardError.new('Error!!!'))
+  
+        result = @save_practice.save_practice
+        expect(result.is_a?(StandardError)).to eq true
+        expect(result.message).to eq 'error removing practice thumbnail'
+      end
+    end
+
+    context 'while crop_main_display_image' do
+      it 'returns a StandardError' do
+        allow(@save_practice).to receive(:crop_main_display_image).and_raise(StandardError.new('Error!!!'))
+  
+        result = @save_practice.save_practice
+        expect(result.is_a?(StandardError)).to eq true
+        expect(result.message).to eq 'error cropping practice thumbnail'
+      end
+    end
+  end
+
+  describe 'when save_practice succeeds' do
+    before do 
+      @practice = Practice.create!(name: 'A public practice 2', tagline: 'Test tagline', initiating_facility: '687HA', date_initiated: Date.new(2011, 12, 31), summary: 'practice summary', support_network_email: 'fake-support-email@example.com', main_display_image: File.new("#{Rails.root}/spec/assets/charmander.png"))
+    end
+
+    context 'while crop_main_display_image' do
+      it 'returns true' do
+        practice_params = {
+          crop_x: 50,
+          crop_y: 10,
+          crop_w: 50,
+          crop_h: 10
+        }
+        save_practice = SavePracticeService.new({ practice: @practice, practice_params: practice_params})
+        
+        result = save_practice.save_practice
+        expect(result).to eq true
+      end
+    end
+
+    context 'while cropping avatar' do
+      it 'returns true' do
+        va_employee = VaEmployee.create(name: 'va employee', role: 'doctor', avatar: File.new("#{Rails.root}/spec/assets/charmander.png") )
+        VaEmployeePractice.create(va_employee: va_employee, practice: @practice)
+        practice_params = {
+          va_employees_attributes: {
+            '0': {
+              id: va_employee.id,
+              _destroy: 'false',
+              crop_x: 50,
+              crop_y: 10,
+              crop_w: 50,
+              crop_h: 10
+            }
+          }
+        }
+        save_practice = SavePracticeService.new({ practice: @practice, practice_params: practice_params})
+        
+        result = save_practice.save_practice
+        expect(result).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
### JIRA issue link
[DM-1492](https://agile6.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=DM&modal=detail&selectedIssue=DM-1492&quickFilter=31)

## Description - what does this code do?
This PR ensures that once the "Publish practice" button is clicked the practice is saved before it is published.

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as a user that can edit/publish a practice.
2. Ensure this user has access to an unpublished practice.
(If you do not have an unpublished practice, you create an unpublished practice as an admin in `.../admin/practices`)
3. Navigate to the unpublished practice
4. a. Make edits to the practice that do not fulfill conditions for publishing (e.g. do not fill out the contact support email)
4. b. Click "Publish practice". Edits to the practice should be saved but you should see a modal saying "Cannot publish"
4. c. BONUS: Make sure you don't see the "Publish practice" button on the "Adoptions" page.
5. a. Make edits to the practice and fulfill all conditions for publishing
5. b. You should be redirected to the practice page with an alert saying the practice is published. All edits should be saved
6. You should no longer see the "Publish practice" button when editing this practice
7. BONUS: Make sure the "Save your progress" and "Continue" buttons work as expected

## Screenshots, Gifs, Videos from application (if applicable)
N/A

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs