### PR TITLE
Dm 1631

### DIFF
--- a/app/admin/practices.rb
+++ b/app/admin/practices.rb
@@ -76,6 +76,7 @@ ActiveAdmin.register Practice do
       user.confirm unless ENV['USE_NTLM'] == 'true'
       user.save
       practice.user = user
+      practice.commontator_thread.subscribe(user)
     end
 
 

--- a/app/mailers/commontator/subscriptions_mailer.rb
+++ b/app/mailers/commontator/subscriptions_mailer.rb
@@ -42,10 +42,9 @@ class Commontator::SubscriptionsMailer < ActionMailer::Base
     else
       @comment_url += @comment.parent.id.to_s
     end
-    @comment_link = "Click here " + @comment_url + " to view #{@comment.thread.commontable.name} comments"
+    @practice_name = @comment.thread.commontable.name
     subject = "Someone has commented on #{@comment.thread.commontable.name} in Diffusion Marketplace"
     subject = "Someone has replied to a comment on #{@comment.thread.commontable.name} in Diffusion Marketplace" unless @comment.parent_id.nil?
     @mail_params[:subject] = subject
-
   end
 end

--- a/app/mailers/commontator/subscriptions_mailer.rb
+++ b/app/mailers/commontator/subscriptions_mailer.rb
@@ -13,8 +13,10 @@ class Commontator::SubscriptionsMailer < ActionMailer::Base
   def setup_variables(comment, recipients)
     @comment = comment
     commentUser = User.find(comment.creator_id).first_name + " " + User.find(comment.creator_id).last_name
-    comment_body = commentUser + " has commented on #{@comment.thread.commontable.name}"
-    comment_body = commentUser + " has replied to a comment on #{@comment.thread.commontable.name}" unless @comment.parent_id.nil?
+
+    @comment_header = commentUser + " has commented on #{@comment.thread.commontable.name}"
+    @comment_header = commentUser + " has replied to a comment on #{@comment.thread.commontable.name}" unless @comment.parent_id.nil?
+
     @thread = @comment.thread
     @creator = @comment.creator
     @mail_params = { from: @thread.config.email_from_proc.call(@thread) }
@@ -40,11 +42,10 @@ class Commontator::SubscriptionsMailer < ActionMailer::Base
     else
       @comment_url += @comment.parent.id.to_s
     end
-    comment_body += "\r\n\r\n"
-    comment_body += "Click here " + @comment_url + " to view #{@comment.thread.commontable.name} comments"
+    @comment_link = "Click here " + @comment_url + " to view #{@comment.thread.commontable.name} comments"
     subject = "Someone has commented on #{@comment.thread.commontable.name} in Diffusion Marketplace"
     subject = "Someone has replied to a comment on #{@comment.thread.commontable.name} in Diffusion Marketplace" unless @comment.parent_id.nil?
     @mail_params[:subject] = subject
-    @mail_params[:body] = comment_body
+
   end
 end

--- a/app/mailers/commontator/subscriptions_mailer.rb
+++ b/app/mailers/commontator/subscriptions_mailer.rb
@@ -1,0 +1,49 @@
+class Commontator::SubscriptionsMailer < ActionMailer::Base
+  helper Commontator::SharedHelper
+  def comment_created(comment, recipients)
+    setup_variables(comment, recipients)
+
+    mail(@mail_params).tap do |message|
+      message.mailgun_recipient_variables = @mailgun_recipient_variables if @using_mailgun
+    end
+  end
+
+  protected
+
+  def setup_variables(comment, recipients)
+    @comment = comment
+    @thread = @comment.thread
+    @creator = @comment.creator
+
+    @mail_params = { from: @thread.config.email_from_proc.call(@thread) }
+
+    @recipient_emails = recipients.map do |recipient|
+      Commontator.commontator_email(recipient, self)
+    end
+
+    @using_mailgun = Rails.application.config.action_mailer.delivery_method == :mailgun
+
+    if @using_mailgun
+      @recipients_header = :to
+      @mailgun_recipient_variables = {}.tap do |mailgun_recipient_variables|
+        @recipient_emails.each { |email| mailgun_recipient_variables[email] = {} }
+      end
+    else
+      @recipients_header = :bcc
+    end
+
+    @mail_params[@recipients_header] = @recipient_emails
+    @creator_name = Commontator.commontator_name(@creator)
+    @commontable_name = Commontator.commontable_name(@thread)
+    @comment_url = Commontator.comment_url(@comment, main_app)
+    @comment_url = @comment_url.split('#')[0] + "#commontator-comment-"
+    if @comment.parent_id.nil?
+      @comment_url += @comment.id.to_s
+    else
+      @comment_url += @comment.parent.id.to_s
+    end
+    subject = "Someone has commented on #{@comment.thread.commontable.name} in Diffusion Marketplace"
+    subject = "Someone has replied to a comment on #{@comment.thread.commontable.name} in Diffusion Marketplace" unless @comment.parent_id.nil?
+    @mail_params[:subject] = subject
+  end
+end

--- a/app/models/commontator/subscription.rb
+++ b/app/models/commontator/subscription.rb
@@ -1,0 +1,22 @@
+module Commontator
+  class Subscription < ActiveRecord::Base
+    belongs_to :subscriber, :polymorphic => true
+    belongs_to :thread
+
+    validates_presence_of :subscriber, :thread
+    validates_uniqueness_of :thread_id, :scope => [:subscriber_type, :subscriber_id]
+
+    def self.comment_created(comment)
+      recipients = comment.thread.subscribers.reject{|s| s == comment.creator}
+      return if recipients.empty?
+
+      mail = SubscriptionsMailer.comment_created(comment, recipients)
+      mail.deliver_now
+    end
+
+    def unread_comments
+      created_at = Comment.arel_table[:created_at]
+      thread.filtered_comments.where(created_at.gt(updated_at))
+    end
+  end
+end

--- a/app/views/commontator/subscriptions_mailer/comment_created.html.erb
+++ b/app/views/commontator/subscriptions_mailer/comment_created.html.erb
@@ -1,11 +1,7 @@
 <h4>
-  <%= t 'commontator.email.comment_created.body',
-        creator_name: @creator_name, commontable_name: @commontable_name %>
+  <%=@comment_header%>
 </h4>
 
-<%= render partial: 'commontator/comments/body', locals: { comment: @comment } %>
-
 <p>
-  <%= t 'commontator.email.thread_link_html',
-         comment_url: @comment_url, commontable_name: @commontable_name %>
+  <%= @comment_link %>
 </p>

--- a/app/views/commontator/subscriptions_mailer/comment_created.html.erb
+++ b/app/views/commontator/subscriptions_mailer/comment_created.html.erb
@@ -3,5 +3,5 @@
 </h4>
 
 <p>
-  <%= @comment_link %>
+  <a href="<%=@comment_url %>">Click here</a> to view <%=@practice_name %> comments
 </p>

--- a/config/initializers/commontator.rb
+++ b/config/initializers/commontator.rb
@@ -248,7 +248,7 @@ Commontator.configure do |config|
   #   :m (manual subscriptions only)
   #   :b (both automatic, when commenting, and manual)
   # Default: :n
-  config.thread_subscription = :m
+  config.thread_subscription = :a
 
   # email_from_proc
   # Type: Proc


### PR DESCRIPTION
### JIRA issue link
dm-1631

## Description - what does this code do?
Formats and sends email to Practice owner about new comment or reply.

## Testing done - how did you test it/steps on how can another person can test it 
1.  Create a practice.
2.  Log in to DM as a different user or have someone else comment or reply to a post within that practice.
expected result: As the owner of the practice I should receive an email regarding the post. see below for email content.

## Screenshots, Gifs, Videos from application (if applicable)
comment:
![image](https://user-images.githubusercontent.com/60527788/80825537-76ef3e80-8b95-11ea-990d-c2803f2c3846.png)

reply:
![image](https://user-images.githubusercontent.com/60527788/80826072-760adc80-8b96-11ea-9dd8-76f5d472592f.png)



## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
Practice Owner (email address we have for Adoptions) gets an email when someone comments on their practice page
Practice Owner gets an email when someone replies to a comment on their practice page
Comment Email Title says “Someone has commented  on [Practice Name] on Diffusion Marketplace”
Reply Email says “Someone has replied to a comment on [Practice Name] in Diffusion Marketplace”
Email contains a link to the “Comments” section of the practice page and IF POSSIBLE, the exact comment itself (TBD) 
Test to make sure emails get generated for both comments and replies
Super Admins DON’T get email notifications unless they own a practice

Email:
**Subject**: Someone has commented on (Or: “replied to a comment on” [Name of practice]

**Body**: [Name of commenter] has commented on (or “replied to a comment on”) [Name of practice].

**Link**: Click here (link to comment) to view [Practice name] comments.


## Definition of done
Practice owner receives correctly formatted emails regarding the post and a link to the post in the Practice's Comment section.