### PR TITLE
DM-1686: Remove sponsored tag from search results

### DIFF
--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -451,7 +451,6 @@ class PracticesController < ApplicationController
     practices.each do |practice|
       practice_hash = JSON.parse(practice.to_json) # convert to hash
       practice_hash['image'] = practice.main_display_image.present? ? practice.main_display_image_s3_presigned_url : ''
-      practice_hash['sponsored_practice'] = practice.practice_partners.any? && practice.practice_partners.find_by(name: 'None of the above, or Unsure').nil?
       if practice.date_initiated
         practice_hash['date_initiated'] = practice.date_initiated.strftime("%B %Y")
       else

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -43,7 +43,6 @@ function searchPracticesPage() {
             var noBackgroundImage = result.item.image ? '' : 'class: fas fa-images fa-3x text-base-lighter search-no-image';
             var background = result.item.image ? 'background: url(' + result.item.image + ')' + ' transparent; background-repeat: no-repeat; background-position: center; background-size: cover;' : 'background-color: #f0f0f0; transparent; background-size: contain; background-repeat: no-repeat; background-position: center; ';
             var favoriteButtonIcon = result.item.user_favorited ? 'fas text-secondary' : 'far text-base';
-            var sponsoredPractice = result.item.sponsored_practice ? '<div class="grid-row margin-top-1"><span class="display-block text-center radius-pill padding-y-1px padding-x-2 bg-base-lighter font-sans-3xs">Sponsored</span></div>' : '<div class="hidden"></div>';
             var favoriteButton =
                 '<a aria-label="Favorite ' + result.item.name + '" tabindex="-1" aria-hidden="true" class="search-favorite-practice-button" id="favorite-button-' + result.item.id +'" data-remote="true" rel="nofollow" data-method="post" href="/practices/' + result.item.slug + '/favorite.js">' +
                     '<i class="' + favoriteButtonIcon + ' fa-heart favorite-icon-' + result.item.id + ' text-no-underline"></i>' +
@@ -64,7 +63,6 @@ function searchPracticesPage() {
             '</div>' +
             '<div class="tablet:grid-col-9 padding-y-105 padding-right-105 padding-left-4">' +
                 '<h2 class="margin-0 truncate-text-search one-line"><a href="/practices/' + result.item.slug + '">' + result.item.name + '</a></h2>' +
-                sponsoredPractice + 
                 '<h4 class="truncate-text-search two-lines text-normal margin-y-1">' + result.item.tagline + '</h4>' +
                 '<p class="practice-details margin-y-1 font-sans-3xs">Created in ' + result.item.date_initiated + ' by the ' + result.item.initiating_facility + '</p>' +
                 '<p class="truncate-text-search three-lines">' + result.item.summary + '</p>' +


### PR DESCRIPTION
### JIRA issue link
[DM-1686](https://agile6.atlassian.net/browse/DM-1686)

## Description - what does this code do?
This PR will remove sponsored tags from search results for each practice.

## Testing done - how did you test it/steps on how can another person can test it 
1. Search for a practice with an associated practice partner.
2. User should no longer see a "Sponsored" tag for each practice result.

## Screenshots, Gifs, Videos from application (if applicable)
<img width="785" alt="Screen Shot 2020-05-12 at 10 41 30 AM" src="https://user-images.githubusercontent.com/20211771/81714882-2dc4a780-943d-11ea-87c7-62ed4e939ad1.png">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)

## Acceptance criteria

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs