### PR TITLE
DM-1681: Search practices by category

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 | `rails go_fish_practices:assign_go_fish_badge` | Assigns the Go Fish badge to all Go Fish practices  |
 | `rails shark_tank_practices:assign_shark_tank_badge` | Assigns the Shark Tank badge to all previous Shark Tank winners  |
 | `rails inet_partner_practices:assign_inet_partner` | Assigns the iNET practice partner to practices that have iNET as a partner  |
+| `rails shark_tank_practices:assign_shark_tank_badge` | Assigns the Shark Tank badge to all previous Shark Tank winners  |
+| `rails categories:add_covid_cats` | Adds COVID related categories and assigns them to practices  |
 #### Ruby version
 
 - `ruby 2.6.3`
@@ -150,6 +152,7 @@ This will run:
 6. `rails go_fish_practices:assign_go_fish_badge` - assigns the Go Fish badge to all Go Fish practices
 7. `rails shark_tank_practices:assign_shark_tank_badge` - assigns the Shark Tank badge to all previous Shark Tank winners
 8. `rails inet_partner_practices:assign_inet_partner` - assigns the iNET practice partner to practices that have iNET as a partner
+9. `rails categories:add_covid_cats` - adds COVID related categories and assigns them to practices
 
 To reset all of the data and do the process all over again, run:
 ```bash

--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -1,0 +1,62 @@
+ActiveAdmin.register Category do
+  filter :name
+  filter :description
+
+  index do
+    selectable_column
+    id_column
+    column :name
+    column :description
+    column :related_terms
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :name
+      row :description
+      row :related_terms
+    end
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :name
+      f.input :description, as: :string
+      # ensures input is displayed as comma separated list
+      f.input :related_terms_raw, label: 'Related Terms', hint: 'Comma separated list (e.g., COVID-19, Coronavirus)'
+    end
+    f.actions
+  end
+
+  controller do
+    before_action :modify_related_terms_for_db, only: [:create, :update]
+
+    def update
+      category = Category.find(params[:id])
+      updated = category.update_attributes(category_params)
+
+      respond_to do |format|
+        if updated
+          format.html { redirect_to admin_category_path(id: params[:id]), notice: 'Category was successfully updated.' }
+        else
+          format.html { redirect_to edit_admin_category_path(id: params[:id]), :flash => { :error => 'There was an error updating your category.' }}
+        end
+      end
+    end
+
+    private
+
+    def category_params
+      params.require(:category).permit(:name, :description, related_terms:[])
+    end
+
+    def modify_related_terms_for_db
+      terms = params[:category][:related_terms_raw]
+      unless terms.blank?
+        params[:category][:related_terms] = terms.split(/\s*,\s*/)
+      end
+    end
+  end
+end

--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -50,12 +50,11 @@ ActiveAdmin.register Category do
 
     def destroy
       deleted = remove_category
-
       respond_to do |format|
         if deleted
-          format.html { redirect_to admin_categories_path(notice: 'Category was successfully updated.') }
+          format.html { redirect_to admin_categories_path(notice: 'Category was successfully deleted.') }
         else
-          format.html { redirect_to edit_admin_category_path(id: params[:id]), :flash => { :error => 'There was an error updating your category.' }}
+          format.html { redirect_to edit_admin_category_path(id: params[:id]), :flash => { :error => 'There was an error deleting your category.' }}
         end
       end
     end
@@ -75,8 +74,8 @@ ActiveAdmin.register Category do
 
     def remove_category
       begin
+        CategoryPractice.where(category_id: params[:id]).map { |cp| cp.destroy! }
         Category.find(params[:id]).destroy!
-        CategoryPractice.where(category_id: category[:id]).map { |cp| cp.destroy! }
         true
       rescue => e
         Rails.logger.error "remove_category error: #{e.message}"

--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -67,8 +67,10 @@ ActiveAdmin.register Category do
 
     def modify_related_terms_for_db
       terms = params[:category][:related_terms_raw]
-      unless terms.blank?
+      if terms.present?
         params[:category][:related_terms] = terms.split(/\s*,\s*/)
+      else
+        params[:category][:related_terms] = []
       end
     end
 

--- a/app/admin/practices.rb
+++ b/app/admin/practices.rb
@@ -34,7 +34,7 @@ ActiveAdmin.register Practice do
     f.inputs  do
       f.input :name, label: 'Practice name'
       f.input :user, label: 'User email', as: :string, input_html: {name: 'user_email'}
-      f.input :categories, as: :select, multiple: true, collection: Category.all.map { |cat| ["#{cat.name.capitalize}", cat.id]}, input_html: { value: @practice_categories }
+      f.input :categories, as: :select, multiple: true, collection: Category.all.order(name: :asc).map { |cat| ["#{cat.name.capitalize}", cat.id]}, input_html: { value: @practice_categories }
     end        # builds an input field for every attribute
     f.actions         # adds the 'Submit' and 'Cancel' buttons
   end

--- a/app/admin/practices.rb
+++ b/app/admin/practices.rb
@@ -34,6 +34,7 @@ ActiveAdmin.register Practice do
     f.inputs  do
       f.input :name, label: 'Practice name'
       f.input :user, label: 'User email', as: :string, input_html: {name: 'user_email'}
+      f.input :categories, as: :select, multiple: true, collection: Category.all.map { |cat| ["#{cat.name.capitalize}", cat.id]}, input_html: { value: @practice_categories }
     end        # builds an input field for every attribute
     f.actions         # adds the 'Submit' and 'Cancel' buttons
   end
@@ -62,6 +63,9 @@ ActiveAdmin.register Practice do
   filter :support_network_email
 
   controller do
+    before_action :set_categories_view, only: :edit
+    after_action :update_categories, only: [:create, :update]
+
     before_create do |practice|
       if params[:user_email].present?
         set_practice_user(practice)
@@ -93,6 +97,35 @@ ActiveAdmin.register Practice do
 
     def find_resource
       scoped_collection.friendly.find(params[:id])
+    end
+
+    def set_categories_view
+      @practice_categories = []
+      current_categories = CategoryPractice.where(practice_id: params[:id])
+      unless current_categories.empty?
+        current_categories.map do |cp|
+          @practice_categories.push(cp[:category_id])
+        end
+      end
+    end
+
+    def update_categories
+      # remove the first category id--first is always empty ''
+      selected_categories = params[:practice][:category_ids].drop(1)
+      selected_categories.map! { |cat| cat.to_i }
+      practice = Practice.find_by(name: params[:practice][:name])
+      current_categories = CategoryPractice.where(practice_id: practice[:id])
+      if selected_categories.length > 0
+        selected_categories.map { |cat| CategoryPractice.find_or_create_by!(category_id: cat, practice_id: practice[:id]) }
+      end
+
+      if params[:action] == 'update' && current_categories.present?
+        if selected_categories.empty?
+          current_categories.map { |cat| cat.destroy! }
+        else
+          current_categories.map { |cat| cat.destroy! unless selected_categories.include? cat.category_id }
+        end
+      end
     end
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -64,7 +64,7 @@ class HomeController < ApplicationController
 
   def search
     ahoy.track "Practice search", {search_term: request.params[:query]} if request.params[:query].present?
-    @practices = Practice.where(approved: true, published: true).order(name: :asc)
+    @practices = Practice.left_outer_joins(:categories).select("practices.*, categories.name as categories_name").where(practices:{ approved: true, published: true }).order(name: :asc).uniq
     @facilities_data = facilities_json['features']
     @practices_json = practices_json(@practices)
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -64,7 +64,7 @@ class HomeController < ApplicationController
 
   def search
     ahoy.track "Practice search", {search_term: request.params[:query]} if request.params[:query].present?
-    @practices = Practice.left_outer_joins(:categories).select("practices.*, categories.name as categories_name").where(practices:{ approved: true, published: true }).order(name: :asc).uniq
+    @practices = Practice.get_with_categories
     @facilities_data = facilities_json['features']
     @practices_json = practices_json(@practices)
   end

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -139,7 +139,7 @@ class PracticesController < ApplicationController
 
   def search
     ahoy.track "Practice search", {search_term: request.params[:query]} if request.params[:query].present?
-    @practices = Practice.left_outer_joins(:categories).select("practices.*, categories.name as categories_name").where(practices:{ approved: true, published: true }).order(name: :asc).uniq
+    @practices = Practice.get_with_categories
     @facilities_data = facilities_json
     @practices_json = practices_json(@practices)
   end

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -139,7 +139,7 @@ class PracticesController < ApplicationController
 
   def search
     ahoy.track "Practice search", {search_term: request.params[:query]} if request.params[:query].present?
-    @practices = Practice.where(approved: true, published: true).order(name: :asc)
+    @practices = Practice.left_outer_joins(:categories).select("practices.*, categories.name as categories_name").where(practices:{ approved: true, published: true }).order(name: :asc).uniq
     @facilities_data = facilities_json
     @practices_json = practices_json(@practices)
   end
@@ -457,6 +457,16 @@ class PracticesController < ApplicationController
         practice_hash['date_initiated'] = practice.date_initiated.strftime("%B %Y")
       else
         practice_hash['date_initiated'] = '(start date unknown)'
+      end
+
+      if practice.categories&.length > 0
+        practice_hash['categories_name'] = []
+
+        practice.categories.each do |category|
+          if category.name != 'None'
+            practice_hash['categories_name'].push category.name
+          end
+        end
       end
 
       # display initiating facility

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -465,6 +465,10 @@ class PracticesController < ApplicationController
         practice.categories.each do |category|
           if category.name != 'None'
             practice_hash['categories_name'].push category.name
+
+            unless category.related_terms.empty?
+              practice_hash['categories_name'].concat(category.related_terms)
+            end
           end
         end
       end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -5,4 +5,10 @@ class Category < ApplicationRecord
 
   has_many :category_practices
   has_many :practices, through: :categories
+
+  attr_accessor :related_terms_raw
+
+  def related_terms_raw
+    self[:related_terms].join(", ") unless self[:related_terms].nil?
+  end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,5 @@
 class Category < ApplicationRecord
-  has_many :sub_impact_categories, class_name: 'Category', foreign_key: 'parent_category_id', dependent: :destroy
+  has_many :sub_categories, class_name: 'Category', foreign_key: 'parent_category_id', dependent: :destroy
   belongs_to :parent_category, class_name: 'Category', optional: true
   acts_as_list
 

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -112,6 +112,7 @@ class Practice < ApplicationRecord
   scope :published,   -> { where(published: true) }
   scope :unpublished,  -> { where(published: false) }
   scope :get_practice_owner_emails, -> {where.not(user_id: nil)}
+  scope :get_with_categories, -> { left_outer_joins(:categories).select("practices.*, categories.name as categories_name").where(practices:{ approved: true, published: true }).order(name: :asc).uniq }
 
   belongs_to :user, optional: true
 

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -95,28 +95,31 @@ function searchPracticesPage() {
     // Adapted from: https://github.com/brunocechet/Fuse.js-with-highlight
     function highlighter(resultItem) {
         resultItem.matches.forEach(function (matchItem) {
-            var text = resultItem.item[matchItem.key];
-            var result = [];
-            var matches = [].concat(matchItem.indices); // limpar referencia
-            var pair = matches.shift();
+            // don't highlight if match was on category since category is not in practice search result text and can't be highlighted
+            if (matchItem.key != 'categories_name') {
+                var text = resultItem.item[matchItem.key];
+                var result = [];
+                var matches = [].concat(matchItem.indices); // limpar referencia
+                var pair = matches.shift();
 
-            for (var i = 0; i < text.length; i++) {
-                var char = text.charAt(i);
-                if (pair && i === pair[0]) {
-                    result.push('<mark>')
+                for (var i = 0; i < text.length; i++) {
+                    var char = text.charAt(i);
+                    if (pair && i === pair[0]) {
+                        result.push('<mark>')
+                    }
+                    result.push(char);
+                    if (pair && i === pair[1]) {
+                        result.push('</mark>');
+                        pair = matches.shift()
+                    }
                 }
-                result.push(char);
-                if (pair && i === pair[1]) {
-                    result.push('</mark>');
-                    pair = matches.shift()
-                }
-            }
-            resultItem.highlight = result.join('');
+                resultItem.highlight = result.join('');
 
-            if (resultItem.children && resultItem.children.length > 0) {
-                resultItem.children.forEach(function (child) {
-                    highlighter(child);
-                });
+                if (resultItem.children && resultItem.children.length > 0) {
+                    resultItem.children.forEach(function (child) {
+                        highlighter(child);
+                    });
+                }
             }
         });
     }
@@ -126,7 +129,7 @@ function searchPracticesPage() {
 
     // Set Fuse.js search options
     var search_options = {
-        keys: ['name', 'tagline', 'description', 'summary', 'initiating_facility'],
+        keys: ['name', 'tagline', 'description', 'summary', 'initiating_facility', 'categories_name'],
         minMatchCharLength: 3,
         tokenize: true,
         shouldSort: true,

--- a/db/migrate/20200514200744_add_related_terms_to_categories.rb
+++ b/db/migrate/20200514200744_add_related_terms_to_categories.rb
@@ -1,0 +1,5 @@
+class AddRelatedTermsToCategories < ActiveRecord::Migration[5.2]
+  def change
+    add_column :categories, :related_terms, :string, array:true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_17_204838) do
+ActiveRecord::Schema.define(version: 2020_05_14_200744) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -170,6 +170,7 @@ ActiveRecord::Schema.define(version: 2020_04_17_204838) do
     t.integer "parent_category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "related_terms", default: [], array: true
   end
 
   create_table "category_practices", force: :cascade do |t|

--- a/lib/tasks/categories.rake
+++ b/lib/tasks/categories.rake
@@ -1,0 +1,18 @@
+# Categories related tasks
+namespace :categories do
+
+  # rails categories:add_covid_cats
+  desc 'Add COVID related categories'
+  task :add_covid_cats => :environment do
+    covid_cats = ['COVID', 'Telehealth', 'Pulmonary Care', 'Environmental Services', 'Follow-up Care']
+
+    covid_cats.each do |cat|
+      if cat == 'COVID'
+        Category.find_or_create_by!(name: cat, related_terms: ['COVID-19', 'Coronavirus'])
+      else
+        Category.find_or_create_by!(name: cat)
+      end
+    end
+    puts "All #{covid_cats.length} COVID related categories have been added."
+  end
+end

--- a/lib/tasks/categories.rake
+++ b/lib/tasks/categories.rake
@@ -1,18 +1,87 @@
 # Categories related tasks
 namespace :categories do
-
   # rails categories:add_covid_cats
-  desc 'Add COVID related categories'
+  desc 'Add COVID related categories to practices'
   task :add_covid_cats => :environment do
-    covid_cats = ['COVID', 'Telehealth', 'Pulmonary Care', 'Environmental Services', 'Follow-up Care']
+    covid_practices = [
+      'advanced-comprehensive-diabetes-care-acdc',
+      'evidence-based-tinnitus-care-for-veterans-nationwide',
+      'home-based-cardiac-rehabilitation',
+      'reach-va',
+      'revamp-remote-veterans-apnea-management-platform',
+      'national-telewound-care-practice',
+      'national-telewound-care-practice',
+      'telerehab-wheeled-mobility-clinic-to-cnh',
+      'telesleep-home-sleep-apnea-testing-program',
+      'video-blood-pressure-visits',
+      'virtual-claims-clinic',
+      'coatesville-vamc-hbpc-interdisciplinary-project',
+      'copd-care',
+      'project-happen',
+      'dedicated-environmental-services-training-specialist',
+      'green-gloves-program',
+      'geri-vet'
+    ]
 
-    covid_cats.each do |cat|
-      if cat == 'COVID'
-        Category.find_or_create_by!(name: cat, related_terms: ['COVID-19', 'COVID 19', 'Coronavirus'])
-      else
-        Category.find_or_create_by!(name: cat)
+    telehealth_practices = [
+      'advanced-comprehensive-diabetes-care-acdc',
+      'evidence-based-tinnitus-care-for-veterans-nationwide',
+      'home-based-cardiac-rehabilitation',
+      'reach-va',
+      'revamp-remote-veterans-apnea-management-platform',
+      'national-telewound-care-practice',
+      'national-telewound-care-practice',
+      'telerehab-wheeled-mobility-clinic-to-cnh',
+      'telesleep-home-sleep-apnea-testing-program',
+      'video-blood-pressure-visits',
+      'virtual-claims-clinic'
+    ]
+
+    pulmonary_care_practices = [
+      'coatesville-vamc-hbpc-interdisciplinary-project',
+      'copd-care',
+      'project-happen'
+    ]
+
+    environmental_services_practices = [
+      'dedicated-environmental-services-training-specialist',
+      'green-gloves-program'
+    ]
+
+    follow_up_care_practices = [
+      'geri-vet'
+    ]
+
+    covid_cats = [
+      Category.find_or_create_by!(name: 'COVID', related_terms: ['COVID-19', 'COVID 19', 'Coronavirus']),
+      Category.find_or_create_by!(name: 'Telehealth'),
+      Category.find_or_create_by!(name: 'Pulmonary Care'),
+      Category.find_or_create_by!(name: 'Environmental Services'),
+      Category.find_or_create_by!(name: 'Follow-up Care')
+    ]
+
+    puts "All #{covid_cats.length} COVID related categories have been added."
+
+    covid_practices.each do |pr|
+      practice = Practice.find_by(slug: pr)
+
+      unless practice.nil?
+        # add to COVID category
+        CategoryPractice.find_or_create_by!(practice: practice, category: covid_cats[0])
+
+        # add to Telehealth category
+        CategoryPractice.find_or_create_by!(practice: practice, category: covid_cats[1]) if telehealth_practices.include? pr
+
+        # add to Pulmonary Care category
+        CategoryPractice.find_or_create_by!(practice: practice, category: covid_cats[2]) if pulmonary_care_practices.include? pr
+
+        # add to Environmental Services category
+        CategoryPractice.find_or_create_by!(practice: practice, category: covid_cats[3]) if environmental_services_practices.include? pr
+
+        # add to Follow-up Care category
+        CategoryPractice.find_or_create_by!(practice: practice, category: covid_cats[4]) if follow_up_care_practices.include? pr
       end
     end
-    puts "All #{covid_cats.length} COVID related categories have been added."
+    puts "#{covid_practices.length} practices have been assigned categories."
   end
 end

--- a/lib/tasks/categories.rake
+++ b/lib/tasks/categories.rake
@@ -8,7 +8,7 @@ namespace :categories do
 
     covid_cats.each do |cat|
       if cat == 'COVID'
-        Category.find_or_create_by!(name: cat, related_terms: ['COVID-19', 'Coronavirus'])
+        Category.find_or_create_by!(name: cat, related_terms: ['COVID-19', 'COVID 19', 'Coronavirus'])
       else
         Category.find_or_create_by!(name: cat)
       end

--- a/lib/tasks/dm.rake
+++ b/lib/tasks/dm.rake
@@ -20,6 +20,7 @@ namespace :dm do
     Rake::Task['go_fish_practices:assign_go_fish_badge'].execute
     Rake::Task['shark_tank_practices:assign_shark_tank_badge'].execute
     Rake::Task['inet_partner_practices:assign_inet_partner'].execute
+    Rake::Task['categories:add_covid_cats'].execute
   end
 
   # rails dm:reset_up

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -16,6 +16,10 @@ describe 'The admin dashboard', type: :feature do
     @admin.add_role(User::USER_ROLES[1].to_sym)
     @approver.add_role(User::USER_ROLES[0].to_sym)
     @practice = Practice.create!(name: 'The Best Practice Ever!', user: @user, initiating_facility: 'Test facility name', tagline: 'Test tagline')
+    @categories = [
+      Category.create!(name: 'COVID', description: 'COVID related practices', related_terms: 'COVID-19, Coronavirus'),
+      Category.create!(name: 'Telehealth', description: 'Telelhealth related practices')
+    ]
     @departments = [
         Department.create!(name: 'Admissions', short_name: 'admissions'),
         Department.create!(name: 'None', short_name: 'none'),
@@ -106,6 +110,9 @@ describe 'The admin dashboard', type: :feature do
       click_link('Dashboard')
       expect(page).to have_current_path(admin_dashboard_path)
 
+      click_link('Categories')
+      expect(page).to have_current_path(admin_categories_path)
+
       click_link('Comments')
       expect(page).to have_current_path(admin_comments_path)
 
@@ -124,6 +131,27 @@ describe 'The admin dashboard', type: :feature do
       click_link('Versions')
       expect(page).to have_current_path(admin_versions_path)
     end
+  end
+
+  it 'should be able to view and update categories' do
+    login_as(@admin, scope: :user, run_callbacks: false)
+    visit '/admin'
+
+    click_link('Categories')
+    expect(page).to have_current_path(admin_categories_path)
+
+    click_link('New Category')
+    expect(page).to have_current_path(new_admin_category_path)
+    fill_in('Name', with: 'Mental Health')
+    fill_in('Description', with: 'Mental Health related practices')
+    fill_in('Related Terms', with: 'emotional health, emotional wellbeing')
+    click_button('Create Category')
+    expect(page).to have_current_path(admin_category_path(Category.last))
+    click_link('Edit Category')
+    fill_in('Related Terms', with: 'psychological health, mental wellbeing')
+    click_button('Update Category')
+    expect(page).to have_current_path(admin_category_path(Category.last))
+    expect(page).to have_content('psychological health, mental wellbeing')
   end
 
   it 'should be able to view and update departments' do

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -161,6 +161,13 @@ describe 'The admin dashboard', type: :feature do
     expect(page).to have_current_path(admin_category_path(Category.last))
     expect(page).to have_content('psychological health, mental wellbeing')
 
+    # edit category - remove related terms
+    click_link('Edit Category')
+    fill_in('Related Terms', with: '')
+    click_button('Update Category')
+    expect(page).to have_current_path(admin_category_path(Category.last))
+    expect(page).to have_no_content('psychological health, mental wellbeing')
+
     # delete category
     visit '/admin/categories'
     expect(page).to have_content('COVID')

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -66,5 +66,20 @@ describe 'Search', type: :feature do
       expect(page).to have_content(@user_practice.initiating_facility)
       expect(page).to have_content('1 result for "Telehealth"')
     end
+
+    it 'should be able to search based on practice categories related terms' do
+      @user_practice.update(published: true, approved: true)
+      category = Category.create!(name: 'Covid', related_terms: ['Coronavirus'])
+      CategoryPractice.create!(category: category, practice: @user_practice)
+
+      visit '/search'
+
+      fill_in('practice-search-field', with: 'Coronavirus')
+      click_button('Search')
+
+      expect(page).to have_content(@user_practice.name)
+      expect(page).to have_content(@user_practice.initiating_facility)
+      expect(page).to have_content('1 result for "Coronavirus"')
+    end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -14,7 +14,7 @@ describe 'Search', type: :feature do
   end
 
   describe 'results' do
-    it 'should show practices that are approved and published'do
+    it 'should show practices that are approved and published' do
       @user_practice.update(published: true, approved: true)
       visit '/search'
       expect(page).to be_accessible.according_to :wcag2a, :section508
@@ -50,9 +50,21 @@ describe 'Search', type: :feature do
 
       # test facility data map for name, positive case
       expect(page).to have_content('Yakima VA Clinic')
-
     end
 
-  end
+    it 'should be able to search based on practice categories' do
+      @user_practice.update(published: true, approved: true)
+      category = Category.create!(name: 'telehealth')
+      CategoryPractice.create!(category: category, practice: @user_practice)
 
+      visit '/search'
+
+      fill_in('practice-search-field', with: 'Telehealth')
+      click_button('Search')
+
+      expect(page).to have_content(@user_practice.name)
+      expect(page).to have_content(@user_practice.initiating_facility)
+      expect(page).to have_content('1 result for "Telehealth"')
+    end
+  end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -3,6 +3,6 @@ require 'rails_helper'
 RSpec.describe Category, type: :model do
   describe 'associations' do
     it { should belong_to(:parent_category).optional  }
-    it { should have_many(:sub_impact_categories) }
+    it { should have_many(:sub_categories) }
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-1681](https://agile6.atlassian.net/browse/DM-1681)

## Description - what does this code do?
This PR implements the following:
- adds COVID related categories and assigns practices to those categories
- implement CRUD operations for categories in ActiveAdmin
- allow admins to add/remove categories to practices in ActiveAdmin
- allow search by practice categories and a categories' related terms

## Testing done - how did you test it/steps on how can another person can test it 
**Before Testing**
- run `rails db:migrate`
- run `rails categories:add_covid_cats` to add the new categories and assign them to practices

**As an admin:**
1. Categories
- Go to `/admin/categories`
- Ensure you see 5 categories: COVID (with COVID-19, COVID 19, Coronavirus as related terms), Telehealth, Pulmonary Care, Environmental Services, Follow-up Care
- Ensure you are able to add new categories, their description, and related terms
- Ensure you are able to edit categories, their description, and related terms
- Ensure you are able to remove a category's related terms
- Ensure you are able to delete categories
BONUS: Ensure you are able to delete categories that a practice has been assigned to

2. Category Practice
- Go to `/admin/practices`
- Click 'Edit' for a practice
- Ensure that if a practice was assigned a category that category is selected in the dropdown list
- Ensure that you can edit a practice's category
- Ensure you can edit both a practice's name and category

**As a user that can search:**
- Go to `/` or `/search`
- Search for 'Coronavirus', 'Covid 19', 'Telehealth'
- Ensure expected results appear for various search terms

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
N/A

## Acceptance criteria
- [X] Ability to add Categories in Active Admin
- [X] Admin can add related terms
- [X] Ability to add categories to practices in Active Admin
- [X] Seed DB with known categories (everything except for the practice that was unpublished -- 3D printing)
- [X] Can search for COVID, COVID-19, Coronavirus (related terms) (Category) 
- [X] Search will show all of the practices we’ve designated as being COVID-related 
- [X] Can search by category (e.g. telehealth) and get related practices) 
- [X] Search by category only returns telehealth practices, not all COVID

## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs