### PR TITLE
DM-1807: correct label when more than 4 complexity aggregate

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,12 +54,12 @@ module ApplicationHelper
   end
 
   def complexity_aggregate_description(aggregate)
-    case aggregate
-    when 2
+    case
+    when aggregate == 2
       return 'Some complexity to implement'
-    when 3
+    when aggregate == 3
       return 'Significant complexity to implement'
-    when 4
+    when aggregate >= 4
       return 'High or large complexity to implement'
     else
       return 'Little to no complexity to implement'


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-1807

## Description - what does this code do?
makes the complexity label correct

## Testing done - how did you test it/steps on how can another person can test it 
1. Edit a practice
2. Go to "Complexity"
3. Choose more than 4 departments - this will make the aggregate greater than 4
4. Save the practice
5. Go to the show view
6. Go to the Complexity section
7. The label next to the four wrenches should say: "High or large complexity to implement"

## Screenshots, Gifs, Videos from application (if applicable)
**Before (BUG):**
![image](https://user-images.githubusercontent.com/19178435/83448020-2eca7280-a406-11ea-9454-3936fef0f641.png)

**After (FIXED):**
![image](https://user-images.githubusercontent.com/19178435/83447936-08a4d280-a406-11ea-9ad8-3dfc902a45d4.png)
