### PR TITLE
DM-1778: Add common name to facility names

### DIFF
--- a/app/assets/javascripts/_facilitySelect.es6
+++ b/app/assets/javascripts/_facilitySelect.es6
@@ -43,6 +43,17 @@ function filterFacilities(facilityData, facilitySelect, stateSelector) {
             .append($("<option></option>")
                 .attr("value", facility.StationNumber)
                 .attr("class", 'usa-select')
-                .text(facility.OfficialStationName))
+                .text(assignFacilityName(facility)))
     });
+}
+
+function assignFacilityName(facility) {
+    let officialName = facility['OfficialStationName']
+    let commonName = facility['CommonName']
+
+    if(officialName.toLowerCase().includes(commonName.toLowerCase())) {
+        return officialName
+    } else {
+        return `${officialName} (${commonName})`
+    }
 }

--- a/app/assets/javascripts/_facilitySelect.es6
+++ b/app/assets/javascripts/_facilitySelect.es6
@@ -46,14 +46,3 @@ function filterFacilities(facilityData, facilitySelect, stateSelector) {
                 .text(assignFacilityName(facility)))
     });
 }
-
-function assignFacilityName(facility) {
-    let officialName = facility['OfficialStationName']
-    let commonName = facility['CommonName']
-
-    if(officialName.toLowerCase().includes(commonName.toLowerCase())) {
-        return officialName
-    } else {
-        return `${officialName} (${commonName})`
-    }
-}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -82,7 +82,11 @@ module ApplicationHelper
   def facility_name(facility_id, facilities_data = nil)
     facilities_data = facilities_data || @facilities_data
     facility_data = facilities_data.find {|f| f['StationNumber'] == facility_id }
-    facility_data.present? ? facility_data['OfficialStationName'] : facility_id
+    if facility_data.present?
+      "#{facility_data["OfficialStationName"]} #{show_common_name(facility_data["OfficialStationName"], facility_data["CommonName"])}"
+    else
+      facility_id
+    end
   end
 
   def email_practice_subject(practice)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -107,6 +107,11 @@ module ApplicationHelper
         object.errors.messages[field_name].join(", ")
       end
     end
-  end 
+  end
 
+  def show_common_name(official_name, common_name)
+    unless official_name.downcase.include?(common_name.downcase)
+      "(#{common_name})"
+    end
+  end
 end

--- a/app/views/maps/_home_map_filters.html.erb
+++ b/app/views/maps/_home_map_filters.html.erb
@@ -97,6 +97,9 @@
               <input id="<%= f["StationNumber"] %>" name="facilities" type="checkbox" value="<%= f["StationNumber"] %>" class="usa-checkbox__input">
               <label for="<%= f["StationNumber"] %>" class="usa-checkbox__label">
                 <%= f["StreetAddressState"] %>: <%= f["OfficialStationName"] %>
+                <% unless f["OfficialStationName"].downcase.include?(f["CommonName"].downcase) %>
+                  (<%= f["CommonName"] %>)
+                <% end %>
               </label>
             <% end %>
           </fieldset>

--- a/app/views/maps/_home_map_filters.html.erb
+++ b/app/views/maps/_home_map_filters.html.erb
@@ -97,9 +97,7 @@
               <input id="<%= f["StationNumber"] %>" name="facilities" type="checkbox" value="<%= f["StationNumber"] %>" class="usa-checkbox__input">
               <label for="<%= f["StationNumber"] %>" class="usa-checkbox__label">
                 <%= f["StreetAddressState"] %>: <%= f["OfficialStationName"] %>
-                <% unless f["OfficialStationName"].downcase.include?(f["CommonName"].downcase) %>
-                  (<%= f["CommonName"] %>)
-                <% end %>
+                  <%= show_common_name(f["OfficialStationName"], f["CommonName"]) %>
               </label>
             <% end %>
           </fieldset>

--- a/app/views/maps/_home_map_marker_modal.html.erb
+++ b/app/views/maps/_home_map_marker_modal.html.erb
@@ -5,7 +5,10 @@
       <div>
         <span class="close text-base-darkest" tabindex="0" role="button" aria-label="Close modal"><span class="fas fa-times"></span></span>
         <div class="margin-bottom-2">
-          <h2 class="margin-top-0 margin-bottom-1"><%= facility['OfficialStationName'] %></h2>
+          <h2 class="margin-top-0 margin-bottom-1">
+            <%= facility['OfficialStationName'] %>
+            <%= show_common_name(facility["OfficialStationName"], facility["CommonName"]) %>
+          </h2>
           <p class="margin-top-1 margin-bottom-0"><%= in_progress %> in-progress
             adoption<%= in_progress == 1 ? '' : 's' %></p>
           <p class="margin-top-1 margin-bottom-0"><%= completed %> completed

--- a/app/views/maps/_infowindow.html.erb
+++ b/app/views/maps/_infowindow.html.erb
@@ -3,9 +3,7 @@
   <p class="margin-top-1p5">
   <b>
     <%= facility['OfficialStationName'] %>
-    <% unless facility["OfficialStationName"].include?(facility["CommonName"]) %>
-      (<%= facility["CommonName"] %>)
-    <% end %>
+    <%= show_common_name(facility["OfficialStationName"], facility["CommonName"]) %>
   </b>
   </p>
   <% if home_page ||= false %>

--- a/app/views/maps/_infowindow.html.erb
+++ b/app/views/maps/_infowindow.html.erb
@@ -1,6 +1,13 @@
 
 <div class="font-sans-sm line-height-sans-1">
-  <p class="margin-top-1p5"><b><%= facility['OfficialStationName'] %></b></p>
+  <p class="margin-top-1p5">
+  <b>
+    <%= facility['OfficialStationName'] %>
+    <% unless facility["OfficialStationName"].include?(facility["CommonName"]) %>
+      (<%= facility["CommonName"] %>)
+    <% end %>
+  </b>
+  </p>
   <% if home_page ||= false %>
     <p class="margin-top-1"><%= completed %> completed adoption<%= completed == 1 ? '' : 's' %></p>
     <p class="margin-top-1"><%= in_progress %> in-progress adoption<%= in_progress == 1 ? '' : 's' %></p>

--- a/app/views/practices/_adoptions_list.html.erb
+++ b/app/views/practices/_adoptions_list.html.erb
@@ -18,9 +18,7 @@
               </span>
       <span class="line-height-sans-505 display-inline-block facility-name-width vertical-align-top">
                 <%= facility["OfficialStationName"] %>
-                <% unless facility["OfficialStationName"].downcase.include?(facility["CommonName"].downcase) %>
-                  (<%= facility["CommonName"] %>)
-                <% end %>
+                <%= show_common_name(facility["OfficialStationName"], facility["CommonName"]) %>
               </span>
       <span class="line-height-sans-505 display-inline-block timeline-width vertical-align-top">
                 <%= current_diffusion_status.start_time.present? ? month_year_date_format(current_diffusion_status.start_time) : 'TBD' %>

--- a/app/views/practices/_adoptions_list.html.erb
+++ b/app/views/practices/_adoptions_list.html.erb
@@ -18,6 +18,9 @@
               </span>
       <span class="line-height-sans-505 display-inline-block facility-name-width vertical-align-top">
                 <%= facility["OfficialStationName"] %>
+                <% unless facility["OfficialStationName"].downcase.include?(facility["CommonName"].downcase) %>
+                  (<%= facility["CommonName"] %>)
+                <% end %>
               </span>
       <span class="line-height-sans-505 display-inline-block timeline-width vertical-align-top">
                 <%= current_diffusion_status.start_time.present? ? month_year_date_format(current_diffusion_status.start_time) : 'TBD' %>

--- a/app/views/practices/_show_authenticated.html.erb
+++ b/app/views/practices/_show_authenticated.html.erb
@@ -124,6 +124,9 @@
           <p class="font-sans-xs-2 line-height-sans-505 margin-bottom-3">
             Created by
             the <%= @facility_data.present? ? @facility_data['OfficialStationName'] : @practice.initiating_facility %>
+            <% if @facility_data.present? %>
+              <%= show_common_name(@facility_data["OfficialStationName"], @facility_data["CommonName"]) %>
+            <% end %>
             in
             <span><%= @practice.date_initiated.present? ? date_format(@practice.date_initiated) : '(start date unknown)' %></span>
           </p>

--- a/app/views/practices/adoptions.html.erb
+++ b/app/views/practices/adoptions.html.erb
@@ -1,4 +1,5 @@
 <% provide :head_tags do %>
+  <%= javascript_include_tag '_assign_facility_name', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag '_facilitySelect', 'data-turbolinks-track': 'reload' %>
   <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
     var facilityData = <%= raw JSON.parse(File.read("#{Rails.root}/lib/assets/vamc.json")).to_json %>;

--- a/app/views/practices/overview.html.erb
+++ b/app/views/practices/overview.html.erb
@@ -1,4 +1,5 @@
 <% provide :head_tags do %>
+  <%= javascript_include_tag '_assign_facility_name', 'data-turbolinks-track': 'reload' %>
   <%= javascript_include_tag '_facilitySelect', 'data-turbolinks-track': 'reload' %>
   <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
     var facilityData = <%= raw JSON.parse(File.read("#{Rails.root}/lib/assets/vamc.json")).to_json %>;

--- a/spec/features/home_map_spec.rb
+++ b/spec/features/home_map_spec.rb
@@ -56,6 +56,14 @@ describe 'HomeMap', type: :feature do
       expect(page).to have_content('James J. Howard Veterans\' Outpatient Clinic')
     end
 
+    it 'displays alternate facility name' do
+      visit '/'
+      open_filters
+
+      find('#practiceListTrigger').click
+      expect(page).to have_content('(Birmingham-Alabama)')
+    end
+
     it 'should show unsuccessful adoptions' do
       visit '/'
       open_filters

--- a/spec/features/practice_editor/adoptions_spec.rb
+++ b/spec/features/practice_editor/adoptions_spec.rb
@@ -27,8 +27,10 @@ describe 'Practice editor', type: :feature do
       # new entry form should clear the entry when "Clear entry" is clicked
       find('button[aria-controls="a0"]').click
       find('label[for="status_in_progress"').click
-      select('Alaska', :from => 'editor_state_select')
-      select('Anchorage VA Medical Center', :from => 'editor_facility_select')
+      select('Alabama', :from => 'editor_state_select')
+      select('Birmingham VA Medical Center', :from => 'editor_facility_select')
+      # alternate name of facility should be displayed
+      expect(page).to have_content('(Birmingham-Alabama)')
       find('#clear_entry').click
       expect(page).to have_field('State', with: '')
 

--- a/spec/features/practice_editor/overview_spec.rb
+++ b/spec/features/practice_editor/overview_spec.rb
@@ -47,6 +47,9 @@ describe 'Practice editor', type: :feature, js: true do
             fill_in('practice_summary', with: 'This is the most super practice ever made')
             find('#practice_partner_1_label').click
             attach_file('Upload photo', @image_path)
+
+            # alternate name of facility should be displayed
+            expect(page).to have_content('(Birmingham-Alabama)')
             @save_button.click
             expect(page).to have_field('practice_name', with: 'A super practice')
             expect(page).to have_field('practice_tagline', with: 'Super duper')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -18,4 +18,34 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe "#show_common_name" do
+    context "when given an official name that contains the common name" do
+      it "does not return the common name" do
+        mock_official_name = 'Chicago-illinois Medical Center'
+        mock_common_name = 'Chicago-Illinois'
+        expect(helper.show_common_name(mock_official_name, mock_common_name)).to eq(nil)
+      end
+
+      it "does not return the common name" do
+        mock_official_name = 'Chicago-illinois Medical Center'
+        mock_common_name = 'Chicago-Illinois'
+        expect(helper.show_common_name(mock_official_name, mock_common_name)).to eq(nil)
+      end
+    end
+
+    context "when given an official name that does not contain the common name" do
+      it "returns the common name" do
+        mock_official_name = 'Jesse Brown Department of Veterans Affairs Medical Center'
+        mock_common_name = 'Chicago-Illinois'
+        expect(helper.show_common_name(mock_official_name, mock_common_name)).to eq('(Chicago-Illinois)')
+      end
+
+      it "returns the common name" do
+        mock_official_name = 'Arlington Memorial Medical Center'
+        mock_common_name = 'Arlington Virginia'
+        expect(helper.show_common_name(mock_official_name, mock_common_name)).to eq('(Arlington Virginia)')
+      end
+    end
+  end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-1778](https://agile6.atlassian.net/browse/DM-1778)

## Description - what does this code do?
This PR adds the common names of VA facilities in parentheses if the common name is not included in the official name.

## Testing done - how did you test it/steps on how can another person can test it 
**Homepage practice map**
1. Click on a map marker. 
2. Ensure the common name appears in parentheses in the info box.
May need to click around to find one. ^_^"
e.g. Raymond G. Murphy Department of Veterans Affairs Medical Center (Albuquerque)
2. Click "Filter results"
3. Click "View list of facilities"
4. Ensure the common name appears in parentheses in the list
5. Click "view more" for a map marker and see that the header facility name also has the common name (if applicable)

**Practice page**
1. Log in as a user in order to view a practice
2. Go to a practice show page
3. Ensure the "Origin" facility has a common name (if applicable)
4. scroll to the map
5. Click on a map marker.
6. Ensure the common name appears in parentheses in the info box (if applicable).
May need to click around to find one. ^_^"

**Overview practice editor page**
1. Log in as a user that can edit a practice
2. Go to the overview edit page
3. In the "Practice Origin" section, ensure you see the common name in the list of facilities (if applicable).

**Adoptions practice editor page**
1. Log in as a user that can edit a practice
2. Go to the adoptions edit page
3. In the list of adoptions, ensure the facility has a common name (if applicable).
4. When editing an adoption or creating an adoption, ensure the facility has a common name (if applicable).

## Screenshots, Gifs, Videos from application (if applicable)
**Homepage practice map**
<img width="883" alt="Screen Shot 2020-06-08 at 11 14 05 AM" src="https://user-images.githubusercontent.com/20211771/84082113-e7635980-a9a4-11ea-99c2-71a48fff8cd1.png">
<img width="954" alt="Screen Shot 2020-06-08 at 11 14 28 AM" src="https://user-images.githubusercontent.com/20211771/84082110-e6322c80-a9a4-11ea-8f56-f522b5b79d08.png">
<img width="770" alt="Screen Shot 2020-06-09 at 11 33 54 AM" src="https://user-images.githubusercontent.com/20211771/84178827-ab82cf80-aa4a-11ea-849a-f4d6de647058.png">


**Practice page**
<img width="961" alt="Screen Shot 2020-06-09 at 12 05 56 PM" src="https://user-images.githubusercontent.com/20211771/84178774-99a12c80-aa4a-11ea-9dbe-982a07d4edb0.png">
<img width="946" alt="Screen Shot 2020-06-08 at 11 14 51 AM" src="https://user-images.githubusercontent.com/20211771/84082106-e5999600-a9a4-11ea-9a22-5a85cb473bc5.png">

**Adoptions practice editor page**
<img width="747" alt="Screen Shot 2020-06-08 at 11 15 32 AM" src="https://user-images.githubusercontent.com/20211771/84082105-e5999600-a9a4-11ea-96f2-f04a10a0094f.png">
<img width="904" alt="Screen Shot 2020-06-08 at 11 18 43 AM" src="https://user-images.githubusercontent.com/20211771/84082101-e4686900-a9a4-11ea-8ec4-223cac6961b3.png">

**Overview practice editor page**
<img width="865" alt="Screen Shot 2020-06-08 at 11 27 27 AM" src="https://user-images.githubusercontent.com/20211771/84082096-e16d7880-a9a4-11ea-9ee7-1a23f7f7f8ae.png">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
N/A

## Acceptance criteria
- [ ] Go through VAMC spreadsheet and highlight all of the VAMC common names that aren’t the same (or roughly the same) as the Formal Name 
- [X]  For each Adoption location where formal name doesn’t match common name, add common name in parentheses e.g.: (Central Western Mass.)
- [X] Have the parentheses common name also display on map on homepage and practice page
- [X] Add in four spots:
- Homepage map
- Practice map
- Adoptions Practice Editor
- Geolocation filter
- Maybe autocomplete? 

## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs