### PR TITLE
DM-1850: add downcaser gem for case insensitive urls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -147,3 +147,4 @@ gem 'wdm', '>= 0.1.0' if Gem.win_platform?
 gem 'gmaps4rails', github: 'agilesix/Google-Maps-for-Rails', ref: 'master'
 gem 'lodash-rails'
 
+gem 'route_downcaser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,6 +410,8 @@ GEM
     roo (2.8.2)
       nokogiri (~> 1)
       rubyzip (>= 1.2.1, < 2.0.0)
+    route_downcaser (1.2.3)
+      activesupport (>= 3.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -605,6 +607,7 @@ DEPENDENCIES
   redis
   rolify
   roo (~> 2.8.0)
+  route_downcaser
   rspec
   rspec-rails
   rspec-retry


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-1850

## Description - what does this code do?
adds `route_downcaser` gem to make urls in application case insenitive

## Testing done - how did you test it/steps on how can another person can test it 
- `bundle install`
- restart server
- browse to: http://localhost:3200/Competitions/Shark-Tank
- ER: shark tank page should come up
- you can do this for any url with any case

