### PR TITLE
DM-1851: Add IE alert to Shark Tank and edit copy

### DIFF
--- a/app/assets/javascripts/ie.es6
+++ b/app/assets/javascripts/ie.es6
@@ -12,8 +12,8 @@ function detectIE() {
                     <div class="usa-alert usa-alert--warning">
                       <div class="usa-alert__body">
                         <p class="browsehappy">
-                            Diffusion Marketplace is not optimized for this browser. 
-                            Some features may not be available. For the best experience, please use the latest versions of 
+                            Diffusion Marketplace is not optimized for this browser.
+                            Some features may not be available. For the best experience, please use the latest versions of
                             Microsoft Edge or Google Chrome.
                         </p>
                       </div>
@@ -21,8 +21,30 @@ function detectIE() {
                 </div>
             `);
         }
-
     }
 
-    $document.on('turbolinks:load', browseHappy);
+    function browseSharkTankHappy() {
+        let locationArray = window.location.href.split('/')
+        if (detectIE() && !$('.browsehappy').length && locationArray.length === 5 && locationArray[3] === 'competitions' && locationArray[4] === 'shark-tank' ) {
+            $('#main-content').prepend(`
+                <div class="grid-container grid-row justify-center">
+                    <div class="grid-col-12 usa-alert usa-alert--error">
+                      <div class="usa-alert__body">
+                        <p class="browsehappy">
+                            Some links or actions on this page are not supported or optimal on this browser.
+                            Please switch to Google Chrome for optimal experience.
+                        </p>
+                      </div>
+                    </div>
+                </div>
+            `);
+        }
+    }
+
+    function loadAlerts() {
+        browseHappy()
+        browseSharkTankHappy()
+    }
+
+    $document.on('turbolinks:load', loadAlerts);
 })(window.jQuery);

--- a/app/views/competitions/shark_tank.html.erb
+++ b/app/views/competitions/shark_tank.html.erb
@@ -98,13 +98,16 @@
           <%= link_to 'Add invite to calendar', asset_path('June_18_invite.ics', skip_pipeline: true), target: '_blank', class: 'shark-tank-faq-link' %>
         </p>
         <br />
+        <p class="line-height-sans-505 margin-bottom-2"><span class="text-bold">Dial-in: </span>844-376-0278</p>
+        <p class="line-height-sans-505 margin-bottom-2"><span class="text-bold">Conference code: </span>745525651#</p>
+        <br />
         <p class="font-sans-sm line-height-sans-505">
           <b>June 23, 2020 Session</b><br />
           <%= link_to 'Add invite to calendar', asset_path('June_23_invite.ics', skip_pipeline: true), target: '_blank', class: 'shark-tank-faq-link' %>
         </p>
         <br />
         <p class="line-height-sans-505 margin-bottom-2"><span class="text-bold">Dial-in: </span>844-376-0278</p>
-        <p class="line-height-sans-505 margin-bottom-2"><span class="text-bold">Conference code: </span>745525651#</p>
+        <p class="line-height-sans-505 margin-bottom-2"><span class="text-bold">Conference code: </span>801303762#</p>
       </div>
       <p class="line-height-sans-505 font-sans-sm margin-bottom-205">
         The sessions will provide an overview of what to expect during the 2020 VHA Shark Tank Competition application process and offer


### PR DESCRIPTION
### JIRA issue link
[DM-1851](https://agile6.atlassian.net/browse/DM-1851)

## Description - what does this code do?
This PR adds an alert for users viewing the Shark Tank in IE and edits the copy for the page.

## Testing done - how did you test it/steps on how can another person can test it 
1. View shark tank page with IE browser
2. Ensure you see an alert
3. Ensure the conference codes are correct for each date
4. View shark tank page with Chrome browser
5. Ensure you do not see an alert

## Screenshots, Gifs, Videos from application (if applicable)
<img width="1317" alt="Screen Shot 2020-06-11 at 5 55 55 PM" src="https://user-images.githubusercontent.com/20211771/84447160-e46aa200-ac0c-11ea-8798-de23c8a43f46.png">
<img width="1309" alt="Screen Shot 2020-06-11 at 5 56 58 PM" src="https://user-images.githubusercontent.com/20211771/84447185-fea48000-ac0c-11ea-9fa0-4c107e2630f9.png">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [X] Add the sentence “Please use Google Chrome to apply.” at the top of the page 
- [X] The conference code listed for the Information Sessions only applies to the session held on June 18th. There is a different conference code for June 23rd. Can we move the currently displayed code up under the June 18th date and list the correct code under the June 23rd date?
- [X] Tues June 23: 801303762

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs