### PR TITLE
DM-1777: Set default alignment for PageImageComponent

### DIFF
--- a/app/views/active_admin/resource/_page_image_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_image_component_form.html.arb
@@ -22,8 +22,7 @@ html = Arbre::Context.new do
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][alignment]" do
             option ''
             %w(left center right).each do |h|
-              option h.capitalize, value: h, selected: component&.alignment == h
-            para 'Defaults to center', class: 'inline-hints'
+              option h.capitalize, value: h, selected: component.present? ? component&.alignment == h : h == 'center'
             end
           end
         end


### PR DESCRIPTION
### JIRA issue link
N/A

## Description - what does this code do?
This PR sets the 'center' option as the default alignment in the select dropdown for the page image component.

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin.
2. Go to /admin/pages
3. Edit a page
4. Add an image component
5. Ensure that the default is set to 'Center'
6. Ensure that saving the image component renders a centered image on the page.

## Screenshots, Gifs, Videos from application (if applicable)
<img width="884" alt="Screen Shot 2020-06-23 at 12 03 55 PM" src="https://user-images.githubusercontent.com/20211771/85433199-b1e47180-b549-11ea-9669-0f6654bd4826.png">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs