### PR TITLE
DM-1885: system status: build revision number and deploy time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ lib/assets/Diffusion_Marketplace.xlsx
 
 .rakeTasks
 .generators
+
+REVISION

--- a/app/controllers/system/status_controller.rb
+++ b/app/controllers/system/status_controller.rb
@@ -1,0 +1,24 @@
+module System
+  class StatusController < ApplicationController
+    before_action :authenticate_active_admin_user!
+
+    def index
+      @deployed_at = deployed_at
+      @revision = revision
+    end
+
+    private
+
+    def revision_file
+      File.new("REVISION") rescue nil
+    end
+
+    def deployed_at
+      revision_file.mtime rescue nil
+    end
+
+    def revision
+      revision_file.read rescue nil
+    end
+  end
+end

--- a/app/views/system/status/index.html.erb
+++ b/app/views/system/status/index.html.erb
@@ -1,0 +1,43 @@
+<% no_file_text = 'No REVISION file' %>
+<div class="grid-container">
+  <div class="grid-col-8 margin-x-auto">
+    <h1>Application Information</h1>
+    <div class="grid-row word-break-break-word hyphens-auto padding-y-105 border-bottom-1px border-black">
+      <div class="tablet:grid-col-6">
+        <p class="padding-left-105 font-sans-xs-2 line-height-sans-505">&nbsp;</p>
+      </div>
+      <div class="tablet:grid-col-6">
+        <p class="padding-left-105 font-sans-xs-2 line-height-sans-505">
+          &nbsp;
+        </p>
+      </div>
+    </div>
+    <div class="grid-row word-break-break-word hyphens-auto padding-y-105 border-bottom-1px border-black">
+      <div class="tablet:grid-col-6">
+        <p class="padding-left-105 font-sans-xs-2 line-height-sans-505">Deployed at</p>
+      </div>
+      <div class="tablet:grid-col-6">
+        <% time = @deployed_at ? @deployed_at.in_time_zone('America/New_York').strftime("%m/%d/%Y %I:%M %Z") : no_file_text %>
+        <p class="padding-left-105 font-sans-xs-2 line-height-sans-505">
+          <%= time %>
+        </p>
+      </div>
+    </div>
+    <div class="grid-row word-break-break-word hyphens-auto padding-y-105 border-bottom-1px border-black">
+      <div class="tablet:grid-col-6 padding-left-105">
+        <p class="font-sans-xs-2 line-height-sans-505">
+          Revision
+        </p>
+      </div>
+      <div class="tablet:grid-col-6 padding-left-105">
+        <p class="font-sans-xs-2 line-height-sans-505">
+          <% if @revision %>
+            <%= link_to @revision, "https://github.com/agilesix/diffusion-marketplace/commits/#{@revision}", target: '_blank' %>
+          <% else %>
+            <%= no_file_text %>
+          <% end %>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,10 @@ Rails.application.routes.draw do
 
   get '/nominate-a-practice', controller: 'nominate_practices', action: 'index', as: 'nominate_a_practice'
 
+  namespace :system do
+    get 'status' => 'status#index', as: 'status'
+  end
+
   # Custom route for reporting a comment
   # get '/practices/:practice_id/comments/:comment_id/report', action: 'report_comment', controller: 'commontator/comments', as: 'report_comment'
 end


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-1885

## Description - what does this code do?
creates the route `/system/status` to view when the application was deployed last, and a link to github of the most recent commits (REVISION number)

the plan is to run 
```
git rev-parse --verify HEAD | tee REVISION
```
at build time to get the `REVISION` file into the build for us to report on in the application

## Testing done - how did you test it/steps on how can another person can test it 
1. without the `REVISION` file created yet, as an admin, browse to `/system/status`
2. you should see "No REVISION file" for the two line items on the page
3. in your terminal, in the root of the application, run this command: `git rev-parse --verify HEAD | tee REVISION`. this will create the `REVISION` file in the root of your application for the application to read
4. refresh the `/system/status` page to see values for "Deployed at" and "REVISION"
  1. For "Deployed at" we are using the eastern time zone as a standard
5. the link of the REVISION number on the page should go to github and list out the most recent commits relative to that REVISION number
6. only admins can see this page (for now)

## Screenshots, Gifs, Videos from application (if applicable)
![image](https://user-images.githubusercontent.com/19178435/87073275-fb7fbe00-c1d1-11ea-9464-cfd15ad516ad.png)
