### PR TITLE
DM-DEVOPS: bump test machine size and add parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - image: redis
 
     working_directory: ~/repo
-
+    resource_class: xlarge
     steps:
       - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ workflows:
                 only: master
 jobs:
   test:
+    parallelism: 4
     docker:
       # specify the version you desire here
       - image: circleci/ruby:2.6.3-node-browsers


### PR DESCRIPTION
in theory, will cut build times to a third of the previous time (15 mins to about 5-7 mins), and lessen build failures in CircleCi