### PR TITLE
DM-1974: render line breaks for practice summary

### DIFF
--- a/app/views/practices/show/introduction/_introduction.html.erb
+++ b/app/views/practices/show/introduction/_introduction.html.erb
@@ -63,7 +63,7 @@
       </div>
       <%# practice summary %>
       <p class="desktop:grid-col-10 grid-col-12 margin-bottom-2 font-sans-lg line-height-sans-6">
-        <%= @practice.summary %>
+        <%= safe_join(h(@practice.summary).split("\r\n"), tag(:br)) %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-1974

## Description - what does this code do?
renders line breaks in the practice summary

## Testing done - how did you test it/steps on how can another person can test it 
1. go to any practice edit page (i.e. http://localhost:3200/practices/preventing-contextual-errors-pce-program/edit/introduction)
2. In the "Summary" make some new lines and returns in the textarea
3. Save
4. Go to the show page (http://localhost:3200/practices/preventing-contextual-errors-pce-program)
5. should render the line breaks as you put them in the PE

## Screenshots, Gifs, Videos from application (if applicable)
![image](https://user-images.githubusercontent.com/19178435/89327681-23cbd280-d641-11ea-8fb4-801a09661bd4.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs