### PR TITLE
DM-2032: Fixed small issue with rendering apostrophes for the summary…

### DIFF
--- a/app/views/practices/_show_authenticated.html.erb
+++ b/app/views/practices/_show_authenticated.html.erb
@@ -114,7 +114,7 @@
         </div>
         <div <%#class="tablet:grid-col-7 padding-x-1"%>>
           <p class="practice-summary margin-0 font-sans-xs-2 line-height-sans-505 word-break-break-word hyphens-auto">
-            <%= safe_join(h(@practice.summary).split("\r\n"), tag(:br)) %>
+            <%= safe_join(raw(@practice.summary).split("\r\n"), tag(:br)) %>
           </p>
         </div>
       </div>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2032

## Description - what does this code do?
Fixes a bug where entering an apostrophe in the summary input for the practice editor would result in the rendering of the HTML Entity Number for an apostrophe in the practice view.

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin.
2. Browse to any practice's overview page in the practice editor.
3. Add an apostrophe to the summary input.
4. Save your progress.
5. Go back to that practice's show page and make sure an apostrophe is rendered.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs