### PR TITLE
New-PV/DM-2032: Fixed issue with rendering apostrophes in the summary…

### DIFF
--- a/app/views/practices/show/introduction/_introduction.html.erb
+++ b/app/views/practices/show/introduction/_introduction.html.erb
@@ -56,7 +56,7 @@
       </div>
       <%# practice summary %>
       <p class="margin-bottom-1 font-sans-lg line-height-sans-6">
-        <%= safe_join(h(@practice.summary).split("\r\n"), tag(:br)) %>
+        <%= safe_join(raw(@practice.summary).split("\r\n"), tag(:br)) %>
       </p>
 
       <%# practice maturity level %>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2032

## Description - what does this code do?
Fixes a bug where entering an apostrophe in the summary input for the practice editor would result in the rendering of the HTML Entity Number for an apostrophe in the practice view.

## Testing done - how did you test it/steps on how can another person can test it
Log in as an admin.
Browse to any practice's introduction page in the practice editor.
Add an apostrophe to the summary input.
Save your progress.
Go back to that practice's show page and make sure an apostrophe is rendered.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs