### PR TITLE
DM-2091: Map Impact Photos and videos to Multimedia

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 | `rails categories:add_covid_cats` | Adds COVID related categories and assigns them to practices  |
 | `rails practice_origin_facilities:move_practice_initiating_facility` | Moves practice initiating facilities to the practice_origin_facilities table  |
 | `rails port_milestones_to_timelines:port_milestones_to_timelines` | Ports data from Milestone table description field to Timelines.milestone field.  |
+| `rails practice_multimedia:transfer_practice_impact_photos` | Ports data from ImpactPhotos table PracticeMultimedia table.  |
+| `rails practice_multimedia:transfer_practice_practice_videos` | Ports data from VideoFile table to PracticeMultimedia table.  |
 
 #### Ruby version
 
@@ -156,6 +158,8 @@ This will run:
 7. `rails inet_partner_practices:assign_inet_partner` - assigns the iNET practice partner to practices that have iNET as a partner
 8. `rails categories:add_covid_cats` - adds COVID related categories and assigns them to practices
 9. `rails practice_origin_facilities:move_practice_initiating_facility` - moves practice initiating facilities to the practice_origin_facilities table
+10. `rails practice_multimedia:transfer_practice_impact_photos` - moves practice impact photos to practice multimedia
+10. `rails practice_multimedia:transfer_practice_videos` - moves practice videos to practice multimedia
 
 To reset all of the data and do the process all over again, run:
 ```bash

--- a/app/views/practices/overview_forms/_image_form.html.erb
+++ b/app/views/practices/overview_forms/_image_form.html.erb
@@ -41,7 +41,7 @@
 
       <div class="dm-cropper-images-container margin-top-2 margin-bottom-1 <%= resource.nil? ? 'grid-col-6' : 'dm-resource-image'%>">
         <% if resource.present? %>
-          <%= image_tag resource.attachment_s3_presigned_url(),
+          <%= image_tag resource.attachment_s3_presigned_url,
                 alt: "practice thumbnail for #",
                 class: 'dm-cropper-thumbnail-original display-none' %>
           <%= image_tag resource.attachment_s3_presigned_url(:thumb),

--- a/lib/tasks/dm.rake
+++ b/lib/tasks/dm.rake
@@ -22,6 +22,8 @@ namespace :dm do
     Rake::Task['categories:add_covid_cats'].execute
     Rake::Task['practice_origin_facilities:move_practice_initiating_facility'].execute
     Rake::Task['milestones:port_milestones_to_timelines'].execute
+    Rake::Task['practice_multimedia:transfer_practice_impact_photos'].execute
+    Rake::Task['practice_multimedia:transfer_practice_videos'].execute
   end
 
   # rails dm:reset_up

--- a/lib/tasks/milestones.rake
+++ b/lib/tasks/milestones.rake
@@ -13,9 +13,9 @@ namespace :milestones do
   task port_milestones_to_timelines: :environment do
     tl_ids = Array.new
     Milestone.all.each do |ms|
-      if(!tl_ids.include?(ms.timeline_id))
+      unless tl_ids.include?(ms.timeline_id)
         tl_ids.push(ms.timeline_id)
-        tl_milestone = "";
+        tl_milestone = ""
         cur_tl_id = ms.timeline_id
         Milestone.all.where(timeline_id: cur_tl_id.to_s).each do |d|
           if d.description.length != 0

--- a/lib/tasks/practice_multimedia.rake
+++ b/lib/tasks/practice_multimedia.rake
@@ -1,0 +1,73 @@
+namespace :practice_multimedia do
+
+  desc 'Transfer/Copy Impact Photos to Practice Multimedia table'
+  task transfer_practice_impact_photos: :environment do
+    practices = Practice.all
+
+    practices.each do |p|
+      p.impact_photos.each do |pip|
+        puts "#{p.id} - #{p.name} Impact Photo #{pip.id}"
+
+        # A not-so-fool-proof way to check if this multimedia photo was already created
+        # just in case this was ran twice in a row on accident
+        multi_photo_exists = p.practice_multimedia.where(name: pip.description)
+
+        if !multi_photo_exists.any?
+          multimedia = p.practice_multimedia.new(
+              resource_type: 'image',
+              name: pip.description
+          )
+
+          multimedia.attachment = pip.attachment
+
+          save_multimedia(p, multimedia)
+        else
+          puts "already created"
+        end
+
+      end
+    end
+    puts "Practice Impact Photos Transfer complete!"
+  end
+
+  desc 'Transfer/Copy Video Files to Practice Multimedia table'
+  task transfer_practice_videos: :environment do
+    practices = Practice.all
+
+    practices.each do |p|
+      p.video_files.each do |pv|
+        puts "#{p.id} - #{p.name} Video #{pv.id}"
+
+        # A not-so-fool-proof way to check if this multimedia video was already created
+        # just in case this was ran twice in a row on accident
+        multi_photo_exists = p.practice_multimedia.where(link_url: pv.url)
+
+        if !multi_photo_exists.any?
+          multimedia = p.practice_multimedia.new(
+              resource_type: 'video',
+              name: pv.description,
+              link_url: pv.url
+          )
+
+          multimedia.attachment = pv.attachment
+          save_multimedia(p, multimedia)
+
+        else
+          puts "already created"
+        end
+
+      end
+    end
+    puts "Practice Videos Transfer complete!"
+  end
+
+  def save_multimedia(p, multimedia)
+    if multimedia.save
+      puts "Created PracticeMultimedia for: #{p.id} - #{p.name}"
+    else
+      puts "Could not create PracticeMultimedia for: #{p.id} - #{p.name}"
+      puts "#{multimedia.errors}"
+    end
+  end
+
+end


### PR DESCRIPTION
[DM-2092, DM-2093] write tasks to create PracticeMultimedia from ImpactPhotos and VideoFiles

### JIRA issue link
https://agile6.atlassian.net/browse/DM-2091

## Description - what does this code do?
exactly what the title says it does

## Testing done - how did you test it/steps on how can another person can test it 
1. run `rails practice_multimedia:transfer_practice_impact_photos`
2.run `rails practice_multimedia:transfer_practice_videos`
3. you can run them again to make sure no duplicates get created
4. check a new practice view page (http://localhost:3200/practices/cards-for-connection) that was outputted in the log to see the multimedia section populated
5. check a new practice editor overview page (http://localhost:3200/practices/cards-for-connection/edit/overview) to see the multimedia section populated

## Screenshots, Gifs, Videos from application (if applicable)
![image](https://user-images.githubusercontent.com/19178435/93539031-7bc64c00-f904-11ea-88f6-141547213a4c.png)

![image](https://user-images.githubusercontent.com/19178435/93539013-6e10c680-f904-11ea-9f3e-927ad4579a06.png)

![multimedia-migration](https://user-images.githubusercontent.com/19178435/93539484-d01dfb80-f905-11ea-8f01-9e0ba4bc9d6a.gif)

![multimedia-migration-editor](https://user-images.githubusercontent.com/19178435/93539623-373bb000-f906-11ea-94b5-4167861f2bdd.gif)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
n/a

## Acceptance criteria
As a user, I would like my video and pictures and comments to be ported over to the new practice pages so that I don't have to re-upload my important multimedia.

AC:

Automatically migrate photos from Impact Section to "Multimedia" section in new practice page design

Automatically migrate caption with the picture it is currently attached to

Automatically migrate videos to multimedia section

Automatically migrate video caption along with the video it's attached to

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs