### PR TITLE
DM-2071: Require practices to have an adoption before publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 | `rails practice_origin_facilities:move_practice_initiating_facility` | Moves practice initiating facilities to the practice_origin_facilities table  |
 | `rails port_milestones_to_timelines:port_milestones_to_timelines` | Ports data from Milestone table description field to Timelines.milestone field.  |
 | `rails practice_multimedia:transfer_practice_impact_photos` | Ports data from ImpactPhotos table PracticeMultimedia table.  |
-| `rails practice_multimedia:transfer_practice_practice_videos` | Ports data from VideoFile table to PracticeMultimedia table.  |
+| `rails practice_multimedia:transfer_practice_videos` | Ports data from VideoFile table to PracticeMultimedia table.  |
 
 #### Ruby version
 

--- a/app/assets/stylesheets/dm/pages/_practice.scss
+++ b/app/assets/stylesheets/dm/pages/_practice.scss
@@ -625,7 +625,7 @@
   margin-top: 11px;
 }
 
-.origin-errors-ul, .contact-errors-ul, .complexity-errors-ul, .complexity-errors-ul, .resources-errors-ul, .overview-errors-ul,
+.origin-errors-ul, .dm-publish-errors-ul, .complexity-errors-ul, .complexity-errors-ul, .resources-errors-ul,
 .impact-errors-ul {
   padding-left: 20px;
   margin-top: 5px;
@@ -634,10 +634,6 @@
     margin-top: 5px;
     margin-bottom: 5px;
   }
-}
-
-.practice-editor-publication-error-container {
-  height: 268px;
 }
 
 .position-arrows {

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -593,7 +593,7 @@ class PracticesController < ApplicationController
   end
 
   def can_publish
-    if @practice.name.present? && @practice.initiating_facility_type.present? && @practice.date_initiated.present? && @practice.summary.present? && @practice.support_network_email.present?
+    if @practice.name.present? && @practice.initiating_facility_type.present? && @practice.date_initiated.present? && @practice.summary.present? && @practice.support_network_email.present? && @practice.diffusion_histories.present?
       @practice.facility? ? @practice.practice_origin_facilities.present? : @practice.initating_facility.present?
     else
       false

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -132,30 +132,14 @@ class PracticesController < ApplicationController
   def update
     current_endpoint = request.referrer.split('/').pop
     updated = true
-    #raise params.inspect
     if params[:practice].present?
-      if params[:practice][:initiating_facility_type].present?
-        facility_type = params[:practice][:initiating_facility_type]
-        if facility_type == "facility"
-          @practice.initiating_facility = params[:editor_facility_select]
-          @practice.initiating_department_office_id = ""
-        elsif facility_type == "visn"
-          @practice.initiating_facility = params[:editor_visn_select]
-          @practice.initiating_department_office_id = ""
-        elsif facility_type == "department"
-          @practice.initiating_facility = params[:editor_office_select]
-          @practice.initiating_department_office_id = params[:initiating_department_office_id]
-        elsif facility_type == "other"
-          @practice.initiating_facility = params[:initiating_facility_other]
-          @practice.initiating_department_office_id = ""
-        end
+      facility_type = params[:practice][:initiating_facility_type] || nil
+      if facility_type.present?
+        set_initiating_fac_params params
       end
       pr_params = {practice: @practice, practice_params: practice_params, current_endpoint: current_endpoint}
       updated = SavePracticeService.new(pr_params).save_practice
-      if facility_type != "facility"
-        origin_facilities = @practice.practice_origin_facilities
-        origin_facilities.destroy_all
-      end
+      clear_origin_facilities if facility_type != "facility"
     end
     respond_to do |format|
       if updated
@@ -178,6 +162,30 @@ class PracticesController < ApplicationController
         format.html { redirect_back fallback_location: root_path }
         format.json { render json: updated, status: :unprocessable_entity }
       end
+    end
+  end
+
+  def clear_origin_facilities
+    origin_facilities = @practice.practice_origin_facilities
+    origin_facilities.destroy_all
+  end
+
+  def set_initiating_fac_params(params)
+    facility_type = params[:practice][:initiating_facility_type]
+    if facility_type == "facility" && params[:practice][:practice_origin_facilities_attributes].present?
+      @practice.initiating_facility = ""
+      @practice.initiating_department_office_id = ""
+    elsif facility_type == "visn" && params[:editor_visn_select].present?
+      @practice.initiating_facility = params[:editor_visn_select]
+      @practice.initiating_department_office_id = ""
+    elsif facility_type == "department" && params[:editor_office_select].present? && params[:initiating_department_office_id].present?
+      @practice.initiating_facility = params[:editor_office_select]
+      @practice.initiating_department_office_id = params[:initiating_department_office_id]
+    elsif facility_type == "other" && params[:initiating_facility_other].present?
+      @practice.initiating_facility = params[:initiating_facility_other]
+      @practice.initiating_department_office_id = ""
+    else
+      params[:practice][:initiating_facility_type] = ""
     end
   end
 
@@ -342,8 +350,13 @@ class PracticesController < ApplicationController
   def publication_validation
     current_endpoint = request.referrer.split('/').pop
     if params[:practice].present?
+      facility_type = params[:practice][:initiating_facility_type] || nil
+      if facility_type.present?
+        set_initiating_fac_params params
+      end
       pr_params = {practice: @practice, practice_params: practice_params, current_endpoint: current_endpoint}
       updated = SavePracticeService.new(pr_params).save_practice
+      clear_origin_facilities if facility_type != "facility"
     end
     respond_to do |format|
       if can_publish
@@ -594,7 +607,7 @@ class PracticesController < ApplicationController
 
   def can_publish
     if @practice.name.present? && @practice.initiating_facility_type.present? && @practice.date_initiated.present? && @practice.summary.present? && @practice.support_network_email.present? && @practice.diffusion_histories.present?
-      @practice.facility? ? @practice.practice_origin_facilities.present? : @practice.initating_facility.present?
+      @practice.has_facility?
     else
       false
     end

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -178,9 +178,9 @@ class PracticesController < ApplicationController
     elsif facility_type == "visn" && params[:editor_visn_select].present?
       @practice.initiating_facility = params[:editor_visn_select]
       @practice.initiating_department_office_id = ""
-    elsif facility_type == "department" && params[:editor_office_select].present? && params[:initiating_department_office_id].present?
-      @practice.initiating_facility = params[:editor_office_select]
-      @practice.initiating_department_office_id = params[:initiating_department_office_id]
+    elsif facility_type == "department" && params[:editor_office_state_select].present? && params[:practice][:initiating_department_office_id].present? && params[:practice][:initiating_facility]
+      @practice.initiating_facility = params[:practice][:initiating_facility]
+      @practice.initiating_department_office_id = params[:practice][:initiating_department_office_id]
     elsif facility_type == "other" && params[:initiating_facility_other].present?
       @practice.initiating_facility = params[:initiating_facility_other]
       @practice.initiating_department_office_id = ""

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -56,6 +56,16 @@ class Practice < ApplicationRecord
     end
   end
 
+  def has_facility?
+    if self.facility?
+      self.practice_origin_facilities.present?
+    elsif self.department?
+      self.initiating_department_office_id.present? && self.initiating_facility.present?
+    elsif self.visn? || self.other?
+      self.initiating_facility.present?
+    end
+  end
+
   # views
   def views
     Ahoy::Event.where_props(practice_id: id).count

--- a/app/views/practices/_adoption_form.html.erb
+++ b/app/views/practices/_adoption_form.html.erb
@@ -158,11 +158,11 @@
     </div>
   </div>
 
-  <div class="">
+  <div>
     <% if adoption %>
-      <%= f.button 'Cancel edits', class: 'usa-button usa-button--outline margin-right-1 padding-2 text-no-underline', type: 'button', id: "cancel_edits_#{adoption&.diffusion_history&.id}", 'data-selector': "diffusion_history_#{adoption&.diffusion_history&.id}" %>
+      <%= f.button 'Cancel edits', class: 'usa-button--outline dm-btn-primary margin-right-1 padding-2 text-no-underline', type: 'button', id: "cancel_edits_#{adoption&.diffusion_history&.id}", 'data-selector': "diffusion_history_#{adoption&.diffusion_history&.id}" %>
     <% else %>
-      <%= f.button 'Clear entry', class: 'usa-button usa-button--outline margin-right-1 padding-2 text-no-underline', type: 'button', id: 'clear_entry' %>
+      <%= f.button 'Clear entry', class: 'usa-button--outline dm-btn-primary margin-right-1 padding-2 text-no-underline', type: 'button', id: 'clear_entry' %>
     <% end %>
     <button type="button" class="usa-button usa-button-primary padding-2" id="adoption_form<%= adoption&.diffusion_history&.id %>_submit" data-disable-with="<%= submit_button_text %>" data-form-id="<%= form_id %>"><%= submit_button_text %></button>
     <% if adoption %>

--- a/app/views/practices/_publication_validation_modal.html.erb
+++ b/app/views/practices/_publication_validation_modal.html.erb
@@ -13,23 +13,31 @@
             <%# Overview errors %>
             <%
               tagline = @practice.tagline
-              initiating_facility = @practice.initiating_facility
+              initiating_facility = @practice.facility? ? @practice.practice_origin_facilities.present? : @practice.initating_facility.present?
               initiating_facility_type = @practice.initiating_facility_type
               summary = @practice.summary
               date_initiated = @practice.date_initiated
+              adoptions = @practice.diffusion_histories
             %>
-            <% if initiating_facility.blank? || date_initiated.blank? || summary.blank? %>
+            <% if initiating_facility_type.blank? || initiating_facility.blank? || date_initiated.blank? || summary.blank? %>
               <p class="text-bold">Overview</p>
-              <ul class="overview-errors-ul">
+              <ul class="dm-publish-errors-ul">
                 <% if date_initiated.blank? %>
                   <li>You must include the initiation date for your practice</li>
                 <% end %>
-                <% if initiating_facility.blank? %>
+                <% if initiating_facility_type.blank? || initiating_facility.blank? %>
                   <li>You must include the initiating facility for your practice</li>
                 <% end %>
                 <% if summary.blank? %>
                   <li>You must include a practice summary</li>
                 <% end %>
+              </ul>
+            <% end %>
+
+            <% if adoptions.blank? %>
+              <p class="text-bold">Adoptions</p>
+              <ul class="dm-publish-errors-ul">
+                <li>You must include at least one adoption</li>
               </ul>
             <% end %>
 
@@ -39,7 +47,7 @@
             %>
             <% if email.blank? %>
               <p class="text-bold">Contact</p>
-              <ul class="contact-errors-ul">
+              <ul class="dm-publish-errors-ul margin-bottom-0">
                 <li>You must include a support network email</li>
               </ul>
             <% end %>

--- a/app/views/practices/_publication_validation_modal.html.erb
+++ b/app/views/practices/_publication_validation_modal.html.erb
@@ -13,7 +13,7 @@
             <%# Overview errors %>
             <%
               tagline = @practice.tagline
-              initiating_facility = @practice.facility? ? @practice.practice_origin_facilities.present? : @practice.initating_facility.present?
+              initiating_facility = @practice.has_facility?
               initiating_facility_type = @practice.initiating_facility_type
               summary = @practice.summary
               date_initiated = @practice.date_initiated

--- a/spec/features/practice_editor/publish_practice_spec.rb
+++ b/spec/features/practice_editor/publish_practice_spec.rb
@@ -34,6 +34,11 @@ describe 'Practice editor', type: :feature, js: true do
       select('Birmingham VA Medical Center (Birmingham-Alabama)', from: last_fac_fac_select[:name])
     end
 
+    def set_initiating_visn
+      find('#initiating_facility_type_visn').sibling('label').click
+      select('VISN-1', :from => 'editor_visn_select')
+    end
+
     def set_adoption
       find('button[aria-controls="a0"]').click
       find('label[for="status_in_progress"').click
@@ -88,10 +93,10 @@ describe 'Practice editor', type: :feature, js: true do
 
       # set required fields in introduction page
       visit practice_introduction_path(@practice)
-      set_initiating_fac
       set_pr_required_fields
-
+      set_initiating_visn
       @publish_button.click
+
       expect(page).to have_no_content('Cannot publish yet')
       expect(page).to have_content("#{@practice.name} has been successfully published to the Diffusion Marketplace")
       # Publish button should be gone if the practice has been published
@@ -100,7 +105,7 @@ describe 'Practice editor', type: :feature, js: true do
       visit practice_path(@practice)
       expect(page).to have_content('practice summary')
       expect(page).to have_content('October 1970')
-      expect(page).to have_content('Birmingham VA Medical Center (Birmingham-Alabama)')
+      expect(page).to have_content('VISN-1')
       expect(page).to have_content('A public practice')
     end
   end

--- a/spec/features/practice_editor/publish_practice_spec.rb
+++ b/spec/features/practice_editor/publish_practice_spec.rb
@@ -19,53 +19,89 @@ describe 'Practice editor', type: :feature, js: true do
       @publish_button = find('#publish-practice-button')
     end
 
-    it 'Should display an error modal that contains missing required fields if any exist' do
-      find('#practice_partner_1_label').click
-      @save_button.click
-      expect(page).to have_field('practice_name', with: 'A public practice')
-      expect(page).to have_checked_field('Diffusion of Excellence')
-
-      # go to impact page since publishing on overview with empty required fields results in form warnings
-      visit practice_impact_path(@practice)
-      @publish_button.click
-      expect(page).to have_content('Cannot publish yet')
-      expect(page).to have_content('You must include the initiation date for your practice')
-      expect(page).to have_content('You must include the initiating facility for your practice')
-      expect(page).to have_content('You must include a practice summary')
-      expect(page).to have_content('You must include a support network email')
+    def set_pr_required_fields
+      fill_in('Summary', with: 'practice summary')
+      select('October', :from => 'editor_date_intiated_month')
+      select('1970', :from => 'editor_date_intiated_year')
     end
 
-    it 'Should save and publish the practice if all required fields are met' do
-      initiated_month = 'October'
-      initiated_year = '1970'
-      summary = 'This is the most super practice ever made'
-
-      visit practice_contact_path(@practice)
-      email = 'test@email.com'
-      fill_in('Main email address', with: email)
-      @save_button.click
-      expect(page).to have_field('Main email address', with: email)
-
-      visit practice_introduction_path(@practice)
+    def set_initiating_fac
       find('#initiating_facility_type_facility').sibling('label').click
       last_fac_field = find_all('.practice-editor-origin-facility-li').last
       last_fac_state_select = last_fac_field.find('select[id*="editor_state_select"]')
       last_fac_fac_select = last_fac_field.find('select[id*="facility_id"]')
       select('Alabama', from: last_fac_state_select[:name])
       select('Birmingham VA Medical Center (Birmingham-Alabama)', from: last_fac_fac_select[:name])
-      select(initiated_month, :from => 'editor_date_intiated_month')
-      select(initiated_year, :from => 'editor_date_intiated_year')
-      fill_in('Summary', with: summary)
+    end
+
+    def set_adoption
+      find('button[aria-controls="a0"]').click
+      find('label[for="status_in_progress"').click
+      select('Alaska', :from => 'editor_state_select')
+      select('Anchorage VA Medical Center', :from => 'editor_facility_select')
+      find('#adoption_form_submit').click
+    end
+
+    it 'should display an error modal only when missing required fields exists' do
+      @publish_button.click
+      page.has_css?('.publication-modal-body')
+      expect(page).to have_content('Cannot publish yet')
+      expect(page).to have_content('This is what you need to do before publishing your practice to the Diffusion Marketplace')
+      expect(page).to have_content('You must include the initiation date for your practice')
+      expect(page).to have_content('You must include the initiating facility for your practice')
+      expect(page).to have_content('You must include a practice summary')
+      expect(page).to have_content('You must include at least one adoption')
+      expect(page).to have_content('You must include a support network email')
+      find('.back-to-editor-button').click
+
+      set_pr_required_fields
+      set_initiating_fac
+      @publish_button.click
+      page.has_css?('.publication-modal-body')
+      expect(page).to have_content('Cannot publish yet')
+      expect(page).to have_content('This is what you need to do before publishing your practice to the Diffusion Marketplace')
+      expect(page).to have_no_content('You must include the initiation date for your practice')
+      expect(page).to have_no_content('You must include the initiating facility for your practice')
+      expect(page).to have_no_content('You must include a practice summary')
+      expect(page).to have_content('You must include at least one adoption')
+      expect(page).to have_content('You must include a support network email')
+
+      visit practice_adoptions_path(@practice)
+      set_adoption
+      @publish_button.click
+      page.has_css?('.publication-modal-body')
+      expect(page).to have_no_content('You must include at least one adoption')
+      expect(page).to have_content('You must include a support network email')
+    end
+
+    it 'Should save and publish the practice if all required fields are met' do
+      # set contact email
+      visit practice_contact_path(@practice)
+      email = 'test@email.com'
+      fill_in('Main email address', with: email)
+      @save_button.click
+      expect(page).to have_field('Main email address', with: email)
+
+      # set adoption
+      visit practice_adoptions_path(@practice)
+      set_adoption
+
+      # set required fields in introduction page
+      visit practice_introduction_path(@practice)
+      set_initiating_fac
+      set_pr_required_fields
 
       @publish_button.click
-      expect(page).to have_content(summary)
-      expect(page).to have_content('October 1970')
-      expect(page).to have_content('Birmingham VA Medical Center (Birmingham-Alabama)')
-      expect(page).to have_content('A public practice')
-      expect(page).to_not have_content('Cannot publish yet')
+      expect(page).to have_no_content('Cannot publish yet')
       expect(page).to have_content("#{@practice.name} has been successfully published to the Diffusion Marketplace")
       # Publish button should be gone if the practice has been published
       expect(page).to_not have_link('Publish practice')
+
+      visit practice_path(@practice)
+      expect(page).to have_content('practice summary')
+      expect(page).to have_content('October 1970')
+      expect(page).to have_content('Birmingham VA Medical Center (Birmingham-Alabama)')
+      expect(page).to have_content('A public practice')
     end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -46,6 +46,12 @@ describe 'Search', type: :feature do
 
   def publish_practice(practice)
     update_practice_introduction(practice)
+    visit(practice_adoptions_path(practice))
+    find('button[aria-controls="a0"]').click
+    find('label[for="status_in_progress"').click
+    select('Alaska', :from => 'editor_state_select')
+    select('Anchorage VA Medical Center', :from => 'editor_facility_select')
+    find('#adoption_form_submit').click
     visit(practice_contact_path(practice))
     fill_in('practice_support_network_email', with: 'dm@va.gov')
     click_button('Publish')

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -30,13 +30,10 @@ describe 'Search', type: :feature do
   def update_practice_introduction(practice)
     login_as(@admin, :scope => :user, :run_callbacks => false)
     visit practice_introduction_path(practice)
-    find('.dm-add-practice-originating-facilities-link').click
-    last_fac_field = find_all('.practice-editor-origin-facility-li').last
-    last_fac_state_select = last_fac_field.find('select[id*="editor_state_select"]')
-    last_fac_fac_select = last_fac_field.find('select[id*="facility_id"]')
-    select('Alabama', from: last_fac_state_select[:name])
-    select('Birmingham VA Medical Center (Birmingham-Alabama)', from: last_fac_fac_select[:name])
-    fill_in('practice_summary', with: 'This is the most super practice ever made')
+    find("#initiating_facility_type_department").sibling('label').click
+    select('VBA', :from => 'editor_department_select')
+    select('Alabama', :from => 'editor_office_state_select')
+    select('Montgomery Regional Office', :from => 'editor_office_select')
     fill_in('practice_summary', with: 'This is the most super practice ever made')
     select('October', :from => 'editor_date_intiated_month')
     select('1970', :from => 'editor_date_intiated_year')


### PR DESCRIPTION
### JIRA issue link
[DM-2071](https://agile6.atlassian.net/browse/DM-2071)

## Description - what does this code do?
This PR requires a practice to have at least one adoption before publishing the practice.

## Testing done - how did you test it/steps on how can another person can test it 
Prereq: Have a practice that is unpublished
1. Log in as a user that can edit a practice.
2. Navigate to the edit page of your practice that is unpublished.
3. Try to publish without an adoption
4. Ensure you are unable to publish the practice and you see why you are unable to publish in the "Can't publish yet" modal
5. Add an adoption and any other required fields
6. Ensure the practice saves and publishes successfully

## Screenshots, Gifs, Videos from application (if applicable)
<img width="541" alt="Screen Shot 2020-09-22 at 4 52 07 PM" src="https://user-images.githubusercontent.com/20211771/93936312-fb349080-fcf3-11ea-915e-ad858401d7c8.png">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [X] In order to publish you must have at least one adoption
- [ ] Verbiage: “In order to publish please add Adoptions” _Note: discussed with Alex the updated copy_
- [X] Only in new, not legacy
- [X] Check is on Publish

## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs