### PR TITLE
DM-2108: Origin story bug

### DIFF
--- a/app/views/practices/_show_authenticated.html.erb
+++ b/app/views/practices/_show_authenticated.html.erb
@@ -10,7 +10,7 @@
       <li class="usa-sidenav__item">
         <a href="#overview" class="dm-tab top-tab scroll-to sidebar-overview" data-target="#overview" data-turbolinks="false">Overview</a>
       </li>
-      <% unless !@practice.origin_story || !@practice.origin_title %>
+      <% if @practice.origin_story %>
         <li class="usa-sidenav__item">
           <a href="#origin" class="dm-tab scroll-to sidebar-origin" data-target="#origin" data-turbolinks="false">Origin</a>
         </li>
@@ -159,7 +159,7 @@
 <%#<div class="dm-background-triangle-bottom "></div>%>
 
 <!-- "Origin of this Practice" section -->
-<% unless !@practice.origin_story || !@practice.origin_title %>
+<% if @practice.origin_story %>
   <section class="padding-bottom-2 margin-bottom-5">
     <div class="grid-container">
       <div class="grid-row grid-gap">


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2108

## Description - what does this code do?
make origin title not required for origin story to show up on practice view

## Testing done - how did you test it/steps on how can another person can test it 
1. fill in origin story in a practice page (i.e. http://localhost:3200/practices/testing/edit/origin)
2. go to practice view (i.e. http://localhost:3200/practices/testing)
3. origin section should show up

## Screenshots, Gifs, Videos from application (if applicable)
![image](https://user-images.githubusercontent.com/19178435/94292608-082ecb00-ff12-11ea-9bf9-3c12a4ef3571.png)
