### PR TITLE
DM-2098: add db backup information to system status page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,5 @@ lib/assets/Diffusion_Marketplace.xlsx
 .rakeTasks
 .generators
 
-REVISION
+REVISION*
+REFRESHED*

--- a/app/controllers/system/status_controller.rb
+++ b/app/controllers/system/status_controller.rb
@@ -5,6 +5,7 @@ module System
     def index
       @deployed_at = deployed_at
       @revision = revision
+      @refreshed_db_with = refreshed
     end
 
     private
@@ -20,5 +21,14 @@ module System
     def revision
       revision_file.read rescue nil
     end
+
+    def refreshed_file
+      File.new("REFRESHED_DB_WITH") rescue nil
+    end
+
+    def refreshed
+      refreshed_file.read rescue nil
+    end
+
   end
 end

--- a/app/views/system/status/index.html.erb
+++ b/app/views/system/status/index.html.erb
@@ -1,4 +1,5 @@
 <% no_file_text = 'No REVISION file' %>
+<% no_refreshed_text = 'No REFRESHED_DB_WITH file' %>
 <div class="grid-container">
   <div class="grid-col-8 margin-x-auto">
     <h1>Application Information</h1>
@@ -39,5 +40,22 @@
         </p>
       </div>
     </div>
+    <div class="grid-row word-break-break-word hyphens-auto padding-y-105 border-bottom-1px border-black">
+      <div class="tablet:grid-col-6 padding-left-105">
+        <p class="font-sans-xs-2 line-height-sans-505">
+          DB Version
+        </p>
+      </div>
+      <div class="tablet:grid-col-6 padding-left-105">
+        <p class="font-sans-xs-2 line-height-sans-505">
+          <% if @refreshed_db_with %>
+            <%= @refreshed_db_with %>
+          <% else %>
+            <%= no_refreshed_text %>
+          <% end %>
+        </p>
+      </div>
+    </div>
+
   </div>
 </div>


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2098

## Description - what does this code do?
adds a bit of information about the database file used to restore on the server

## Testing done - how did you test it/steps on how can another person can test it 
0. browse to http://localhost:3200/system/status
1. the "No REFRESHED_DB_WITH file" text should show up
1. in a terminal run  `echo Refreshed DB with vadm_db_backup at $(date +"%Y-%m-%d-%H%M-%Z") | tee REFRESHED_DB_WITH`
  1. this mimics what the db backup/refresh script does in VAEC when the db is done being refreshed: what backup file was used and when
2. browse to http://localhost:3200/system/status
3. the DB Version should be populated on the right

## Screenshots, Gifs, Videos from application (if applicable)
![image](https://user-images.githubusercontent.com/19178435/94299614-bfc8da80-ff1c-11ea-8809-0a1fb7540972.png)

![image](https://user-images.githubusercontent.com/19178435/94299421-82644d00-ff1c-11ea-931d-ea564da6b843.png)
