### PR TITLE
DM-2115: Move homepage map

### DIFF
--- a/app/assets/stylesheets/dm/_classes.scss
+++ b/app/assets/stylesheets/dm/_classes.scss
@@ -48,6 +48,11 @@ DM COMMONLY USED CLASSES - use these if you really mean it!
 .dm-background-steel-grey {
   background-color: $dm-color-steel-grey !important;
 }
+
+.dm-primary-5v-background {
+  background-color: $dm-color-primary-5v !important;
+}
+
 /* Linear Gradient backgrounds */
 
 .dm-background-linear-gradient-down-cool {

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -19,32 +19,39 @@
   float: left;
 }
 
-.homepage-covid-section-container {
+.homepage-featured-link {
+  width: auto;
+  display: inline-block;
+  margin-bottom: 24px;
+  text-decoration: none;
+  color: $dm-color-dark-black;
+
+  &:hover {
+    color: $dm-color-light-black !important;
+  }
+
+  &:visited {
+    color: $dm-default-visited-link-purple !important;
+  }
+
+  h2 {
+    margin-top: 0 !important;
+  }
+}
+
+.homepage-featured-section-see-more-link {
+  position: absolute;
+  bottom: 50px;
+  left: 20px;
+}
+
+.homepage-featured-section-container {
   height: 309px;
   max-width: 60rem !important;
   padding-top: 43px !important;
   padding-left: 33px !important;
   padding-bottom: 30px;
   background-color: $dm-color-baby-blue;
-
-  .homepage-covid-link {
-    width: auto;
-    display: inline-block;
-    margin-bottom: 24px;
-    text-decoration: none;
-
-    &:hover {
-      color: $dm-color-light-black !important;
-    }
-
-    &:visited {
-      color: $dm-default-visited-link-purple !important;
-    }
-
-    h2 {
-      margin-top: 0 !important;
-    }
-  }
 
   p {
     margin-bottom: 30px;

--- a/app/assets/stylesheets/dm/pages/_home.scss
+++ b/app/assets/stylesheets/dm/pages/_home.scss
@@ -4,8 +4,6 @@
 
 @import '../variables/colors';
 
-
-
 .home .circle {
   width: 130px;
   height: 130px;
@@ -66,10 +64,10 @@
       border: 2px solid $dm-color-lighter-black !important;
     }
   }
+}
 
-  .virus-image-container {
-    align-self: center;
-  }
+.dm-virus-image-container {
+  display: none;
 }
 
 .tt-dataset-facilityNames {
@@ -114,7 +112,19 @@
     width: 100% !important;
   }
 
-  .virus-image-container {
+  .dm-virus-image-container {
     margin: 0 auto;
+  }
+}
+
+@media screen and (min-width: 1024px) {
+  .dm-diffusion-map-more {
+    position: absolute;
+    bottom: -117px;
+   }
+
+  .dm-virus-image-container {
+    display: block;
+    align-self: center;
   }
 }

--- a/app/assets/stylesheets/dm/variables/_colors.scss
+++ b/app/assets/stylesheets/dm/variables/_colors.scss
@@ -45,6 +45,7 @@ $dm-color-super-grey: #424344;
 $dm-color-super-violet-ish: #004795;
 $dm-color-royal-blue: #205493;
 $dm-color-pale-blue: #0071BB;
+$dm-color-primary-5v: #EDF5FF;
 $dm-color-steel-grey: #585C62;
 $dm-color-light-grey: #D6D7D9;
 $dm-color-lighter-grey: #DCDEE0;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,14 +1,13 @@
 class HomeController < ApplicationController
 
   def index
-    @top_practice = Practice.find_by_highlight true
-    @featured_practices = Practice.where featured: true
     @practices = Practice.searchable_practices
     @favorite_practices = current_user&.favorite_practices || []
-
     @facilities_data = facilities_json
+  end
 
-    @vamc_facilities = JSON.parse(File.read("#{Rails.root}/lib/assets/vamc.json"))
+  def diffusion_map
+    @vamc_facilities = facilities_json
 
     @diffused_practices = DiffusionHistory.all.reject { |dh| !dh.practice.published }
 
@@ -61,6 +60,7 @@ class HomeController < ApplicationController
 
       marker.infowindow render_to_string(partial: 'maps/infowindow', locals: {diffusion_histories: dhg[1], completed: completed, in_progress: in_progress, unsuccessful: unsuccessful, facility: facility, home_page: true})
     end
+    render 'maps/diffusion_map'
   end
 
   def pii_phi_information

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -16,58 +16,54 @@
       <div class="grid-row">
         <div class="tablet:grid-col-8">
           <p class="measure-none font-sans-lg line-height-sans-505">
-            This site is designed to help spread important and life-saving promising practices throughout the VA Healthcare System.
+            This site is designed to help spread important and life-saving promising practices throughout the VA
+            Healthcare System.
           </p>
         </div>
       </div>
     </div>
   </section>
 
-  <section class="margin-bottom-5">
-    <div class="grid-container homepage-covid-section-container height-auto">
-      <div class="grid-row ie-grid-row-12">
-        <div class="grid-col-8">
-          <%= link_to '/covid-19', class: 'homepage-covid-link' do %>
-            <h2 class="font-sans-xl">COVID-19<span class="fas fa-angle-right margin-left-105"></span></h2>
-          <% end %>
-          <p class="line-height-sans-505 font-sans-sm">
-            The Diffusion Marketplace has practices that help VHA respond to COVID-19.
-            We have assembled a group of practices for frontline staff and administrators responding to the changing medical landscape.
-          </p>
-          <%= link_to 'See more', '/covid-19', class: 'usa-button usa-button--outline' %>
+  <section class=" grid-container margin-bottom-5">
+    <div class="grid-row grid-gap-3">
+      <div class="grid-col-8">
+        <div class="homepage-featured-section-container height-auto position-relative">
+          <div class="grid-row">
+            <div class="grid-col-8">
+              <%= link_to '/covid-19', class: 'homepage-featured-link' do %>
+                <h2 class="font-sans-xl">COVID-19<span class="fas fa-angle-right margin-left-105"></span></h2>
+              <% end %>
+              <p class="line-height-sans-505 font-sans-sm">
+                The Diffusion Marketplace has practices that help VHA respond to COVID-19.
+                We have assembled a group of practices for frontline staff and administrators responding to the changing
+                medical landscape.
+              </p>
+              <%= link_to 'See more', '/covid-19', class: 'usa-button usa-button--outline' %>
+            </div>
+            <div class="grid-col-fill text-center virus-image-container">
+              <i class="fas fa-viruses fa-9x text-primary-darker"></i>
+            </div>
+          </div>
         </div>
-        <div class="grid-col-fill text-center virus-image-container">
-          <i class="fas fa-viruses fa-9x text-primary-darker"></i>
+      </div>
+      <div class="grid-col-4">
+        <div class="homepage-featured-section-container height-full dm-primary-5v-background position-relative">
+          <div class="grid-row">
+            <div class="grid-col-12">
+              <%= link_to '/diffusion-map', class: 'homepage-featured-link' do %>
+                <h2 class="font-sans-xl">Diffusion map<span class="fas fa-angle-right margin-left-105"></span></h2>
+              <% end %>
+              <p class="line-height-sans-505 font-sans-sm">
+                See practices mapped out by location.
+              </p>
+              <%= link_to 'See more', '/diffusion-map', class: 'usa-button usa-button--outline' %>
+            </div>
+          </div>
+
         </div>
       </div>
     </div>
   </section>
-
-  <% if ENV['GOOGLE_API_KEY'].present? %>
-    <% provide :head_tags do %>
-      <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
-        <%= render partial: 'maps/marker_icons', formats: [:js] %>
-        <%= render partial: 'maps/map_data', formats: [:js] %>
-      <% end %>
-      <%= javascript_include_tag 'diffusion_history/home_map', 'data-turbolinks-track': 'reload' %>
-      <%= javascript_include_tag 'diffusion_history/_map_utilities', 'data-turbolinks-track': 'reload' %>
-    <% end %>
-      <section class="grid-container margin-bottom-4" id="map-of-diffusion">
-        <h4 class="font-sans-xl margin-bottom-1 margin-top-0 line-height-sans-205">Map of diffusion</h4>
-        <p class="font-sans-lg margin-bottom-2">Explore how practices are being adopted across the country.</p>
-        <div class="padding-y-105 padding-x-2 bg-gold radius-md margin-bottom-205">
-          <span class="text-bold">Note:</span>&nbsp;<span>More practices will be added to this map in the next few months.</span>
-        </div>
-        <button id="filterResultsTrigger" class="map-filters-trigger usa-button text-bold display-block margin-bottom-105 padding-2">
-          Filter results
-        </button>
-        <button type="button" class="usa-button text-bold hidden margin-bottom-105 padding-2 bg-base-lightest text-ink" id="filterClose" aria-label="Close map filters">Close filters</button>
-        <div class="width-full position-relative">
-          <div id="map" style="width: 100%; height: 633px;"></div>
-          <%= render 'maps/home_map_filters' %>
-        </div>
-    </section>
-  <% end %>
 
   <section class="padding-top-2">
     <div class="grid-container">
@@ -77,7 +73,7 @@
         <% @practices.each do |p| %>
           <% if p.present? %>
             <div class="tablet:grid-col-3 padding-y-105">
-              <%= render partial: 'practices/favorite_button', locals: {practice: p, featured: false, col_4: false } %>
+              <%= render partial: 'practices/favorite_button', locals: {practice: p, featured: false, col_4: false} %>
               <%= render partial: 'practices/marketplace_card', locals: {practice: p, featured: false} %>
             </div>
           <% end %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -26,10 +26,10 @@
 
   <section class=" grid-container margin-bottom-5">
     <div class="grid-row grid-gap-3">
-      <div class="grid-col-8">
-        <div class="homepage-featured-section-container height-auto position-relative">
-          <div class="grid-row">
-            <div class="grid-col-8">
+      <div class="desktop:grid-col-8">
+        <div class="homepage-featured-section-container height-auto position-relative margin-bottom-3 desktop:margin-bottom-0 padding-right-4 desktop:padding-right-0">
+          <div class="grid-row desktop:margin-right-2">
+            <div class="grid-col-12 desktop:grid-col-8">
               <%= link_to '/covid-19', class: 'homepage-featured-link' do %>
                 <h2 class="font-sans-xl">COVID-19<span class="fas fa-angle-right margin-left-105"></span></h2>
               <% end %>
@@ -40,14 +40,14 @@
               </p>
               <%= link_to 'See more', '/covid-19', class: 'usa-button usa-button--outline' %>
             </div>
-            <div class="grid-col-fill text-center virus-image-container">
+            <div class="grid-col-fill text-center dm-virus-image-container">
               <i class="fas fa-viruses fa-9x text-primary-darker"></i>
             </div>
           </div>
         </div>
       </div>
-      <div class="grid-col-4">
-        <div class="homepage-featured-section-container height-full dm-primary-5v-background position-relative">
+      <div class="desktop:grid-col-4">
+        <div class="homepage-featured-section-container height-full dm-primary-5v-background position-relative padding-right-4 desktop:padding-right-0">
           <div class="grid-row">
             <div class="grid-col-12">
               <%= link_to '/diffusion-map', class: 'homepage-featured-link' do %>
@@ -56,7 +56,9 @@
               <p class="line-height-sans-505 font-sans-sm">
                 See practices mapped out by location.
               </p>
-              <%= link_to 'See more', '/diffusion-map', class: 'usa-button usa-button--outline' %>
+              <div class="dm-diffusion-map-more">
+                <%= link_to 'See more', '/diffusion-map', class: 'usa-button usa-button--outline' %>
+              </div>
             </div>
           </div>
 

--- a/app/views/maps/diffusion_map.html.erb
+++ b/app/views/maps/diffusion_map.html.erb
@@ -1,0 +1,30 @@
+<section class="grid-container margin-top-5 margin-bottom-4" id="map-of-diffusion">
+  <% if ENV['GOOGLE_API_KEY'].present? %>
+    <% provide :head_tags do %>
+      <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
+        <%= render partial: 'maps/marker_icons', formats: [:js] %>
+        <%= render partial: 'maps/map_data', formats: [:js] %>
+      <% end %>
+      <%= javascript_include_tag 'diffusion_history/home_map', 'data-turbolinks-track': 'reload' %>
+      <%= javascript_include_tag 'diffusion_history/_map_utilities', 'data-turbolinks-track': 'reload' %>
+    <% end %>
+
+    <h4 class="font-sans-xl margin-bottom-1 margin-top-0 line-height-sans-205">Map of diffusion</h4>
+    <p class="font-sans-lg margin-bottom-2">Explore how practices are being adopted across the country.</p>
+    <div class="padding-y-105 padding-x-2 bg-gold radius-md margin-bottom-205">
+      <span class="text-bold">Note:</span>&nbsp;<span>More practices will be added to this map in the next few months.</span>
+    </div>
+    <button id="filterResultsTrigger" class="map-filters-trigger usa-button text-bold display-block margin-bottom-105 padding-2">
+      Filter results
+    </button>
+    <button type="button" class="usa-button text-bold hidden margin-bottom-105 padding-2 bg-base-lightest text-ink" id="filterClose" aria-label="Close map filters">Close
+      filters
+    </button>
+    <div class="width-full position-relative">
+      <div id="map" style="width: 100%; height: 633px;"></div>
+      <%= render 'maps/home_map_filters' %>
+    </div>
+  <% else %>
+    <p>The map is not enabled for this site.</p>
+  <% end %>
+</section>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,8 +21,8 @@
       </button>
       <ul class="usa-nav__primary usa-accordion">
         <li class="usa-nav__primary-item">
-          <a class="usa-nav__link <%= 'dm-current-link' if request.fullpath == '/competitions/shark-tank' %>" href="/competitions/shark-tank">
-            <span>Shark Tank</span>
+          <a class="usa-nav__link <%= 'dm-current-link' if request.fullpath == '/diffusion-map' %>" href="/diffusion-map">
+            <span>Diffusion map</span>
           </a>
         </li>
         <li class="usa-nav__primary-item">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -80,6 +80,7 @@ Rails.application.routes.draw do
   end
 
   get '/nominate-a-practice', controller: 'nominate_practices', action: 'index', as: 'nominate_a_practice'
+  get '/diffusion-map', controller: 'home', action: 'diffusion_map', as: 'diffusion_map'
 
   namespace :system do
     get 'status' => 'status#index', as: 'status'

--- a/spec/features/home_map_spec.rb
+++ b/spec/features/home_map_spec.rb
@@ -9,6 +9,7 @@ describe 'HomeMap', type: :feature do
     Rake::Task['importer:import_answers'].execute
     Rake::Task['diffusion_history:flow3'].execute
     ENV['GOOGLE_API_KEY'] = ENV['GOOGLE_TEST_API_KEY']
+    visit '/diffusion-map'
   end
 
   after do
@@ -25,8 +26,6 @@ describe 'HomeMap', type: :feature do
 
   context 'when visiting the homepage' do
     it 'the map shows up and filters are working' do
-      visit '/'
-
       # filters button
       expect(page).to be_accessible.within '#filterResultsTrigger'
 
@@ -47,7 +46,6 @@ describe 'HomeMap', type: :feature do
     end
 
     it 'autocompletes facility names' do
-      visit '/'
       open_filters
 
       find('#facility_name').set('Ja')
@@ -57,7 +55,6 @@ describe 'HomeMap', type: :feature do
     end
 
     it 'displays alternate facility name' do
-      visit '/'
       open_filters
 
       find('#practiceListTrigger').click
@@ -65,7 +62,6 @@ describe 'HomeMap', type: :feature do
     end
 
     it 'should show unsuccessful adoptions' do
-      visit '/'
       open_filters
       all('.usa-checkbox__label').first.click
       find('.adoption-status-label:nth-of-type(2)').click

--- a/spec/features/shared/header_spec.rb
+++ b/spec/features/shared/header_spec.rb
@@ -28,18 +28,18 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
   describe 'header links' do
     it 'should exist' do
       within('header.usa-header') do
-        expect(page).to have_content('Shark Tank')
-        expect(page).to have_link(href: '/competitions/shark-tank')
+        expect(page).to have_content('Diffusion map')
+        expect(page).to have_link(href: '/diffusion-map')
         expect(page).to have_content('COVID-19')
         expect(page).to have_link(href: '/covid-19')
         expect(page).to have_content('Your profile')
       end
     end
 
-    context 'clicking on the shark tank link' do
-      it 'should redirect to shark tank page' do
-        click_on 'Shark Tank'
-        expect(page).to have_current_path('/competitions/shark-tank')
+    context 'clicking on the diffusion map link' do
+      it 'should redirect to diffusion map page' do
+        click_on 'Diffusion map'
+        expect(page).to have_current_path('/diffusion-map')
       end
     end
 


### PR DESCRIPTION
### JIRA issue link
[DM-2115](https://agile6.atlassian.net/browse/DM-2115)

## Description - what does this code do?
This PR moves the homepage diffusion map over to its own page.

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to the homepage.
2. Ensure the diffusion map no longer appears on the homepage.
3. Ensure the navigation has "Diffusion map" instead of "Shark Tank" and it redirects to the `/diffusion-map` page.
4. Ensure the new diffusion map banner links to the `/diffusion-map` page.
5. Ensure the banner is mobile friendly.
(Note: Virus icon disappears on smaller screen widths as discussed with Becca)
6. Ensure the diffusion map and filters load as intended on the `/diffusion-map` page.

## Screenshots, Gifs, Videos from application (if applicable)
<img width="427" alt="Screen Shot 2020-10-01 at 9 21 09 AM" src="https://user-images.githubusercontent.com/20211771/94814686-a8c83380-03c7-11eb-8b41-3517dc257371.png">
<img width="970" alt="Screen Shot 2020-10-01 at 9 21 17 AM" src="https://user-images.githubusercontent.com/20211771/94814695-a9f96080-03c7-11eb-9003-2722caf0e0dc.png">
<img width="1105" alt="Screen Shot 2020-10-01 at 9 21 23 AM" src="https://user-images.githubusercontent.com/20211771/94814710-ae257e00-03c7-11eb-869c-402f17db0364.png">
<img width="1129" alt="Screen Shot 2020-10-01 at 9 21 47 AM" src="https://user-images.githubusercontent.com/20211771/94814712-aebe1480-03c7-11eb-815a-080b5be30a79.png">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
[Figma](https://www.figma.com/file/FogT5mBUVl8rE7OgWDQWeJ/VADM?node-id=7011%3A4)

## Acceptance criteria
- [X] Remove Map
- [X] Move map to its own page (just a page with the map on it we can get mock-ups if needed)
- [X] Have "Diffusion Map" _(note: should be "Diffusion map" as seen in Figma)_ in header for site, replacing Shark Tank
- [X] Follow mock up and just move all practices up to where the map was
- [X] Add "Diffusion Map" _(note: should be "Diffusion map" as seen in Figma)_ static box to header next to COVID stuff (See mock-up)
- [X] “See practices mapped out by location”
- [X] URL: va.gov/diffusion-map

Conversation with Becca additional AC:
- [X] Make mobile friendly
- [X] Remove virus image on smaller screen widths

## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs