### PR TITLE
Fix button style on homepage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/agilesix/uswds-rails.git
-  revision: 79b82e18284a94e6a8e083b6fbf022a66df75140
+  revision: bc5c729d132ef27ccdcf26bdf6cfac530d92ebeb
   branch: 2.8.1
   specs:
     uswds-rails (2.8.1)

--- a/app/assets/javascripts/_introduction_image_editor.es6
+++ b/app/assets/javascripts/_introduction_image_editor.es6
@@ -137,11 +137,8 @@
       $(target).closest('.dm-cropper-boundary').find('.dm-cropper-thumbnail-original').addClass('display-none')
       let croppedCanvas = $image.data('cropper').getCroppedCanvas({ width: 310 })
 
-        let url = croppedCanvas.toDataURL();
-        let image = new Image();
-        image.src = url;
-        image.classList.add('dm-cropper-thumbnail-modified')
-        $(target).closest('.dm-cropper-boundary').find($imgsContainer).append(image)
+      $(target).closest('.dm-cropper-boundary').find($imgsContainer).append(croppedCanvas)
+      $(target).closest('.dm-cropper-boundary').find('canvas').addClass('dm-cropper-thumbnail-modified')
     }
   }
 
@@ -266,7 +263,6 @@
       _toggleImageView({ isCrop: false, target: event.target })
       _toggleCropperBtnView({ visible: false, target: event.target });
       _toggleEditBtn({ visible: true, target: event.target });
-      _setCropBoxValues({ isCrop: false, target: event.target });
     });
   }
 

--- a/app/assets/javascripts/_overview_image_editor.es6
+++ b/app/assets/javascripts/_overview_image_editor.es6
@@ -97,7 +97,7 @@
     $(target)
       .closest('.dm-cropper-boundary').find(".usa-file-input")
       .replaceWith(`
-        <input id="practice_${area}-input-single_RANDOM_NUMBER_OR_SOMETHING" class="dm-cropper-upload-image usa-hint usa-file-input ${area}-image-attachment" type="file" name="practice[practice_${area}_attributes][RANDOM_NUMBER_OR_SOMETHING_${type}][attachment]" accept=".jpg,.jpeg,.png" aria-describedby="practice_${area}-input-single_RANDOM_NUMBER_OR_SOMETHING-hint"/>
+        <input id="practice_${area}-input-single_RANDOM_NUMBER_OR_SOMETHING" class="dm-cropper-upload-image usa-hint usa-file-input ${area}-image-attachment" type="file" name="practice[practice_${area}_attributes][RANDOM_NUMBER_OR_SOMETHING_${type}][attachment]" accept=".jpg,.jpeg,.png" />
       `)
     // add event listener again
     $('.dm-cropper-upload-image').on('change', (event) => {

--- a/app/assets/javascripts/_overview_image_editor.es6
+++ b/app/assets/javascripts/_overview_image_editor.es6
@@ -97,7 +97,7 @@
     $(target)
       .closest('.dm-cropper-boundary').find(".usa-file-input")
       .replaceWith(`
-        <input id="practice_${area}_RANDOM_NUMBER_OR_SOMETHING" class="dm-cropper-upload-image usa-hint usa-file-input ${area}-image-attachment" type="file" name="practice[practice_${area}_attributes][RANDOM_NUMBER_OR_SOMETHING_${type}][attachment]" accept=".jpg,.jpeg,.png" />
+        <input id="practice_${area}_attributes_RANDOM_NUMBER_OR_SOMETHING_image" class="dm-cropper-upload-image usa-hint usa-file-input ${area}-image-attachment" type="file" name="practice[practice_${area}_attributes][RANDOM_NUMBER_OR_SOMETHING_${type}][attachment]" accept=".jpg,.jpeg,.png" />
       `)
     // add event listener again
     $('.dm-cropper-upload-image').on('change', (event) => {

--- a/app/assets/javascripts/_overview_image_editor.es6
+++ b/app/assets/javascripts/_overview_image_editor.es6
@@ -97,7 +97,7 @@
     $(target)
       .closest('.dm-cropper-boundary').find(".usa-file-input")
       .replaceWith(`
-        <input id="practice_${area}-input-single_RANDOM_NUMBER_OR_SOMETHING" class="dm-cropper-upload-image usa-hint usa-file-input ${area}-image-attachment" type="file" name="practice[practice_${area}_attributes][RANDOM_NUMBER_OR_SOMETHING_${type}][attachment]" accept=".jpg,.jpeg,.png" />
+        <input id="practice_${area}_RANDOM_NUMBER_OR_SOMETHING" class="dm-cropper-upload-image usa-hint usa-file-input ${area}-image-attachment" type="file" name="practice[practice_${area}_attributes][RANDOM_NUMBER_OR_SOMETHING_${type}][attachment]" accept=".jpg,.jpeg,.png" />
       `)
     // add event listener again
     $('.dm-cropper-upload-image').on('change', (event) => {

--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -147,9 +147,18 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
         link_form.attr('class', `margin-bottom-5`);
         link_form.find('.dm-cancel-add-button-row').remove();
 
+        let area = sArea
+        let resourceType = ''
+        if (sArea === 'optional_attachment' || sArea === 'core_attachment' || sArea === 'support_attachment') {
+            if (sType === 'file') {
+                area = 'resources'
+                resourceType = '_' + sArea.substr(0, sArea.indexOf('_attachment'));
+            }
+        }
+
         const deleteEntryHtml = `
             <div class="grid-col-12 margin-top-2" align="right">
-               <input type="hidden" value="false" name="practice[practice_${sArea}_attributes][${nGuid}_${sType}][_destroy]"/>
+               <input type="hidden" value="false" name="practice[practice_${area}_attributes][${nGuid}_${sType}${resourceType}][_destroy]"/>
                <button type="button" data-area="${sArea}" data-type="${sType}" class="usa-button--unstyled dm-btn-warning line-height-26 remove_nested_fields">
                     Delete entry
                </button>
@@ -177,22 +186,25 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
         //clear form_inputs
         $.each(formToClear.find('input:not([type="hidden"])'), function (i, ele) {
             $(ele).val(null);
+
             if (ele.type === 'file' && sType === 'file') {
                 let area = sArea
+                let resourceType = ''
+
                 if (sArea === 'optional_attachment' || sArea === 'core_attachment' || sArea === 'support_attachment') {
                     area = 'resources'
+                    resource_type = sArea.substr(0, sArea.indexOf('_attachment')) + '_';
                 }
-
                 $(ele)
                     .closest('.usa-file-input')
                     .replaceWith(`
-                        <input id="practice_${area}-input-single_RANDOM_NUMBER_OR_SOMETHING" class="usa-hint usa-file-input" type="file" name="practice[practice_${area}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" aria-describedby="practice_${area}-input-single_RANDOM_NUMBER_OR_SOMETHING-hint" />
+                        <input id="practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_file_${resource_type}attachment" class="usa-hint usa-file-input" type="file" name="practice[practice_${area}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" />
                     `);
             } else if (ele.type === 'file' && sType === 'image') {
                 $(ele)
                     .closest('.usa-file-input')
                     .replaceWith(`
-                    <input id="practice_${sArea}-input-single_RANDOM_NUMBER_OR_SOMETHING" class="usa-hint usa-file-input dm-cropper-upload-image" type="file" name="practice[practice_${sArea}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".jpg,.jpeg,.png" />
+                    <input id="practice_${sArea}_RANDOM_NUMBER_OR_SOMETHING" class="usa-hint usa-file-input dm-cropper-upload-image" type="file" name="practice[practice_${sArea}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".jpg,.jpeg,.png" />
                 `);
             }
         });
@@ -243,9 +255,18 @@ function validateFormFields(formSelector, sArea, sType, target) {
     clearErrorDivs(sArea, sType, target);
     let errDiv = null;
     if (sType === "file") {
-        const sAttachment = document.getElementsByClassName(sArea + '-file-attachment');
-        const sName = document.getElementById('practice_' + sArea + '_attributes_RANDOM_NUMBER_OR_SOMETHING_file_name');
-        const sDesc = document.getElementById('practice_' + sArea + '_attributes_RANDOM_NUMBER_OR_SOMETHING_file_description');
+        let resource_type = ''
+        if (sArea.includes('_attachment')) {
+            resource_type = sArea.substr(0, sArea.indexOf('_attachment')) + '_';
+        }
+
+        let area = sArea
+        if (sArea === 'optional_attachment' || sArea === 'core_attachment' || sArea === 'support_attachment') {
+            area = 'resources'
+        }
+        const sAttachment = $(`.${sArea}-file-attachment`)
+        const sName = $(`#practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_file_${resource_type}name`)
+        const sDesc = $(`#practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_file_${resource_type}description`)
 
         if (sAttachment[0].value === "") {
             errDiv = document.getElementById(sArea + '_file_err_message_attachment');
@@ -264,9 +285,6 @@ function validateFormFields(formSelector, sArea, sType, target) {
             errDiv.style.display = "block";
             displayTextInputErrorStyles(sName);
             displayInputErrorStyles(sName, `.${sArea}-input-container`);
-            // Hide name error message
-            hideTextInputErrorStyles(sDesc);
-            hideInputErrorStyles(sDesc, `.${sArea}-input-container`);
             return false;
         } else {
             hideTextInputErrorStyles(sName);
@@ -396,7 +414,6 @@ function clearErrorDivs(sArea, sType, target) {
         document.getElementById(sArea + '_file_err_message_description').style.display = "none";
         document.getElementById(sArea + '_file_err_message_attachment').style.display = "none";
     }
-
     // VIDEO
     if (sType === 'video') {
         document.getElementById(sArea + '_video_err_message_name').style.display = "none";

--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -168,7 +168,7 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
 
         if ($(`#${container}`).children().length === 0) {
             let title = `${sType}s`
-            let titleHTML = `<div id="${sArea}_${sType}_section_text" class="text-bold font-sans-3xs margin-bottom-2 text-ls-1 line-height-15px" >${title.toUpperCase()}:</div>`
+            let titleHTML = `<h5 id="${sArea}_${sType}_section_text" class="text-bold font-sans-3xs margin-bottom-2 margin-top-0 text-ls-1 line-height-15px" >${title.toUpperCase()}:</h5>`
             $(`#${container}`).append(titleHTML)
         }
         link_form.appendTo(`#${container}`);
@@ -222,10 +222,9 @@ function attachDeleteResourceListener() {
         let type = $(e.target).data('type');
         $(e.target).parents('div[id*=' + area + '_' + type + '_form]').hide();
 
-        let visibleChildDivs = $(e.target).closest(`#display_${area}_${type}`).find('div:visible');
+        let visibleChildDivs = $(e.target).closest(`#display_${area}_${type}`).find($('div.margin-bottom-5:visible'));
         // remove title of section if there are no items
-        if (visibleChildDivs.length === 1) {
-            visibleChildDivs[0].hide;
+        if (visibleChildDivs.length === 0) {
             let elementId = area + '_' + type + '_section_text';
             let newEle = document.getElementById(elementId);
             if(newEle != null) {

--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -168,7 +168,7 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
 
         if ($(`#${container}`).children().length === 0) {
             let title = `${sType}s`
-            let titleHTML = `<h5 id="${sArea}_${sType}_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px" >${title.toUpperCase()}:</h5>`
+            let titleHTML = `<div id="${sArea}_${sType}_section_text" class="text-bold font-sans-3xs margin-bottom-2 text-ls-1 line-height-15px" >${title.toUpperCase()}:</div>`
             $(`#${container}`).append(titleHTML)
         }
         link_form.appendTo(`#${container}`);
@@ -223,7 +223,7 @@ function attachDeleteResourceListener() {
         let type = $(e.target).data('type');
         $(e.target).parents('div[id*=' + area + '_' + type + '_form]').hide();
 
-        let visibleChildDivs = $(e.target).closest(`#display_${area}_${type}`).find('h5:visible');
+        let visibleChildDivs = $(e.target).closest(`#display_${area}_${type}`).find('div:visible');
         // remove title of section if there are no items
         if (visibleChildDivs.length === 1) {
             visibleChildDivs[0].hide;

--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -168,10 +168,11 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
 
         if ($(`#${container}`).children().length === 0) {
             let title = `${sType}s`
-            let titleHTML = `<div id="${sArea}_${sType}_section_text" class="text-bold margin-bottom-2" >${title.toUpperCase()}:</div>`
+            let titleHTML = `<h5 id="${sArea}_${sType}_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px" >${title.toUpperCase()}:</h5>`
             $(`#${container}`).append(titleHTML)
         }
         link_form.appendTo(`#${container}`);
+        console.log('container', container)
         document.getElementById(container).style.display = 'block';
 
         //clear form_inputs
@@ -222,7 +223,7 @@ function attachDeleteResourceListener() {
         let type = $(e.target).data('type');
         $(e.target).parents('div[id*=' + area + '_' + type + '_form]').hide();
 
-        let visibleChildDivs = $(e.target).closest(`#display_${area}_${type}`).find('div:visible');
+        let visibleChildDivs = $(e.target).closest(`#display_${area}_${type}`).find('h5:visible');
         // remove title of section if there are no items
         if (visibleChildDivs.length === 1) {
             visibleChildDivs[0].hide;

--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -204,7 +204,7 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
                 $(ele)
                     .closest('.usa-file-input')
                     .replaceWith(`
-                    <input id="practice_${sArea}_RANDOM_NUMBER_OR_SOMETHING_image" class="usa-hint usa-file-input dm-cropper-upload-image" type="file" name="practice[practice_${sArea}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".jpg,.jpeg,.png" />
+                    <input id="practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_image" class="usa-hint usa-file-input dm-cropper-upload-image" type="file" name="practice[practice_${sArea}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".jpg,.jpeg,.png" />
                 `);
             }
         });
@@ -394,7 +394,7 @@ function validateFormFields(formSelector, sArea, sType, target) {
             hideInputErrorStyles(sDesc, `.${sArea}-input-container`);
         }
     } else if (sType === 'image') {
-        const sAttachment = document.getElementById(`practice_${sArea}_RANDOM_NUMBER_OR_SOMETHING_image`);
+        const sAttachment = document.getElementById(`practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_image`);
         const sName = document.getElementById('practice_' + sArea + '_attributes_RANDOM_NUMBER_OR_SOMETHING_image_name');
 
         if (sAttachment.value === "") {

--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -179,7 +179,7 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
             $(ele).val(null);
             if (ele.type === 'file' && sType === 'file') {
                 let area = sArea
-                if (sArea === 'optional_attachment' || 'core_attachment' || 'support_attachment') {
+                if (sArea === 'optional_attachment' || sArea === 'core_attachment' || sArea === 'support_attachment') {
                     area = 'resources'
                 }
 

--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -178,10 +178,15 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
         $.each(formToClear.find('input:not([type="hidden"])'), function (i, ele) {
             $(ele).val(null);
             if (ele.type === 'file' && sType === 'file') {
+                let area = sArea
+                if (sArea === 'optional_attachment' || 'core_attachment' || 'support_attachment') {
+                    area = 'resources'
+                }
+
                 $(ele)
                     .closest('.usa-file-input')
                     .replaceWith(`
-                        <input id="practice_${sArea}-input-single_RANDOM_NUMBER_OR_SOMETHING" class="usa-hint usa-file-input" type="file" name="practice[practice_${sArea}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" aria-describedby="practice_${sArea}-input-single_RANDOM_NUMBER_OR_SOMETHING-hint" />
+                        <input id="practice_${area}-input-single_RANDOM_NUMBER_OR_SOMETHING" class="usa-hint usa-file-input" type="file" name="practice[practice_${area}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" aria-describedby="practice_${area}-input-single_RANDOM_NUMBER_OR_SOMETHING-hint" />
                     `);
             } else if (ele.type === 'file' && sType === 'image') {
                 $(ele)

--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -147,18 +147,18 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
         link_form.attr('class', `margin-bottom-5`);
         link_form.find('.dm-cancel-add-button-row').remove();
 
-        let area = sArea
-        let resourceType = ''
+        let area = sArea;
+        let resource_type = '';
         if (sArea === 'optional_attachment' || sArea === 'core_attachment' || sArea === 'support_attachment') {
             if (sType === 'file') {
-                area = 'resources'
-                resourceType = '_' + sArea.substr(0, sArea.indexOf('_attachment'));
+                area = 'resources';
+                resource_type = '_' + sArea.substr(0, sArea.indexOf('_attachment'));
             }
         }
 
         const deleteEntryHtml = `
             <div class="grid-col-12 margin-top-2" align="right">
-               <input type="hidden" value="false" name="practice[practice_${area}_attributes][${nGuid}_${sType}${resourceType}][_destroy]"/>
+               <input type="hidden" value="false" name="practice[practice_${area}_attributes][${nGuid}_${sType}${resource_type}][_destroy]"/>
                <button type="button" data-area="${sArea}" data-type="${sType}" class="usa-button--unstyled dm-btn-warning line-height-26 remove_nested_fields">
                     Delete entry
                </button>
@@ -189,7 +189,7 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
 
             if (ele.type === 'file' && sType === 'file') {
                 let area = sArea
-                let resourceType = ''
+                let resource_type = ''
 
                 if (sArea === 'optional_attachment' || sArea === 'core_attachment' || sArea === 'support_attachment') {
                     area = 'resources'
@@ -265,8 +265,8 @@ function validateFormFields(formSelector, sArea, sType, target) {
             area = 'resources'
         }
         const sAttachment = $(`.${sArea}-file-attachment`)
-        const sName = $(`#practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_file_${resource_type}name`)
-        const sDesc = $(`#practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_file_${resource_type}description`)
+        const sName = $(`#practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_file_${resource_type}name`);
+        const sDesc = $(`#practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_file_${resource_type}description`);
 
         if (sAttachment[0].value === "") {
             errDiv = document.getElementById(sArea + '_file_err_message_attachment');

--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -192,7 +192,7 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
                 $(ele)
                     .closest('.usa-file-input')
                     .replaceWith(`
-                    <input id="practice_${sArea}-input-single_RANDOM_NUMBER_OR_SOMETHING" class="usa-hint usa-file-input dm-cropper-upload-image" type="file" name="practice[practice_${sArea}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".jpg,.jpeg,.png" aria-describedby="practice_${sArea}-input-single_RANDOM_NUMBER_OR_SOMETHING-hint" />
+                    <input id="practice_${sArea}-input-single_RANDOM_NUMBER_OR_SOMETHING" class="usa-hint usa-file-input dm-cropper-upload-image" type="file" name="practice[practice_${sArea}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".jpg,.jpeg,.png" />
                 `);
             }
         });

--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -172,7 +172,6 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
             $(`#${container}`).append(titleHTML)
         }
         link_form.appendTo(`#${container}`);
-        console.log('container', container)
         document.getElementById(container).style.display = 'block';
 
         //clear form_inputs

--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -204,7 +204,7 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
                 $(ele)
                     .closest('.usa-file-input')
                     .replaceWith(`
-                    <input id="practice_${sArea}_RANDOM_NUMBER_OR_SOMETHING" class="usa-hint usa-file-input dm-cropper-upload-image" type="file" name="practice[practice_${sArea}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".jpg,.jpeg,.png" />
+                    <input id="practice_${sArea}_RANDOM_NUMBER_OR_SOMETHING_image" class="usa-hint usa-file-input dm-cropper-upload-image" type="file" name="practice[practice_${sArea}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".jpg,.jpeg,.png" />
                 `);
             }
         });
@@ -264,16 +264,22 @@ function validateFormFields(formSelector, sArea, sType, target) {
         if (sArea === 'optional_attachment' || sArea === 'core_attachment' || sArea === 'support_attachment') {
             area = 'resources'
         }
-        const sAttachment = document.getElementsByClassName(`${sArea}-file-attachment`)
+        const sAttachment = document.getElementById(`practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_file_${resource_type}attachment`);
         const sName = document.getElementById(`practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_file_${resource_type}name`);
         const sDesc = document.getElementById(`practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_file_${resource_type}description`);
 
-        if (sAttachment[0].value === "") {
+        if (sAttachment.value === "") {
             errDiv = document.getElementById(sArea + '_file_err_message_attachment');
             errDiv.style.display = "block";
             $(sAttachment).closest('.usa-file-input').prepend($(errDiv));
             displayAttachmentErrorStyles(sAttachment, '.usa-file-input__target', 'div.grid-col-12');
             displayInputErrorStyles(sAttachment, '.grid-col-12');
+            // Hide name error message
+            hideTextInputErrorStyles(sName);
+            hideInputErrorStyles(sName, `.${sArea}-input-container`);
+            // Hide description error message
+            hideTextInputErrorStyles(sDesc);
+            hideInputErrorStyles(sDesc, `.${sArea}-input-container`);
             return false;
         } else {
             hideAttachmentErrorStyles(sAttachment, '.usa-file-input__target', 'div.grid-col-12');
@@ -285,6 +291,9 @@ function validateFormFields(formSelector, sArea, sType, target) {
             errDiv.style.display = "block";
             displayTextInputErrorStyles(sName);
             displayInputErrorStyles(sName, `.${sArea}-input-container`);
+            // Hide description error message
+            hideTextInputErrorStyles(sDesc);
+            hideInputErrorStyles(sDesc, `.${sArea}-input-container`);
             return false;
         } else {
             hideTextInputErrorStyles(sName);
@@ -385,10 +394,10 @@ function validateFormFields(formSelector, sArea, sType, target) {
             hideInputErrorStyles(sDesc, `.${sArea}-input-container`);
         }
     } else if (sType === 'image') {
-        const sAttachment = document.getElementsByClassName(sArea + '-image-attachment');
+        const sAttachment = document.getElementById(`practice_${sArea}_RANDOM_NUMBER_OR_SOMETHING_image`);
         const sName = document.getElementById('practice_' + sArea + '_attributes_RANDOM_NUMBER_OR_SOMETHING_image_name');
 
-        if (sAttachment[0].value === "") {
+        if (sAttachment.value === "") {
             errDiv = document.getElementById(sArea + '_image_err_message_attachment');
             errDiv.style.display = "block";
             $(sAttachment).closest('.usa-file-input').prepend($(errDiv));
@@ -444,32 +453,32 @@ function clearErrorDivs(sArea, sType, target) {
 }
 
 function displayInputErrorStyles(inputTitle, elem) {
-    $(inputTitle).closest(elem).addClass('overview-input-error');
+    $(inputTitle).closest(elem).addClass('input-error');
     $(inputTitle).parent().find('label').addClass('usa-label--error');
 }
 
 function hideInputErrorStyles(inputTitle, elem) {
-    $(inputTitle).closest(elem).removeClass('overview-input-error');
+    $(inputTitle).closest(elem).removeClass('input-error');
     $(inputTitle).parent().find('label').removeClass('usa-label--error');
 }
 
 function displayTextInputErrorStyles(inputTitle) {
-    $(inputTitle).addClass('overview-text-input-error');
+    $(inputTitle).addClass('text-input-error');
     $(inputTitle).parent().find('label').addClass('usa-label--error');
 }
 
 function hideTextInputErrorStyles(inputTitle) {
-    $(inputTitle).removeClass('overview-text-input-error');
+    $(inputTitle).removeClass('text-input-error');
     $(inputTitle).parent().find('label').removeClass('usa-label--error');
 }
 
 function displayAttachmentErrorStyles(inputTitle, elem1, elem2) {
-    $(inputTitle).closest(elem1).addClass('overview-attachment-input-target-error');
+    $(inputTitle).closest(elem1).addClass('attachment-input-target-error');
     $(inputTitle).closest(elem2).find('label').addClass('usa-label--error margin-bottom-0');
 }
 
 function hideAttachmentErrorStyles(inputTitle, elem1, elem2) {
-    $(inputTitle).closest(elem1).removeClass('overview-attachment-input-target-error');
+    $(inputTitle).closest(elem1).removeClass('attachment-input-target-error');
     $(inputTitle).closest(elem2).find('label').removeClass('usa-label--error margin-bottom-0');
 }
 

--- a/app/assets/javascripts/practice_editor_utilities.es6
+++ b/app/assets/javascripts/practice_editor_utilities.es6
@@ -193,12 +193,12 @@ function attachAddResourceListener(formSelector, container, sArea, sType) {
 
                 if (sArea === 'optional_attachment' || sArea === 'core_attachment' || sArea === 'support_attachment') {
                     area = 'resources'
-                    resource_type = sArea.substr(0, sArea.indexOf('_attachment')) + '_';
+                    resource_type = sArea.substr(0, sArea.indexOf('_attachment'));
                 }
                 $(ele)
                     .closest('.usa-file-input')
                     .replaceWith(`
-                        <input id="practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_file_${resource_type}attachment" class="usa-hint usa-file-input" type="file" name="practice[practice_${area}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" />
+                        <input id="practice_${sArea}_attributes_RANDOM_NUMBER_OR_SOMETHING_file_${resource_type ? resource_type + '_' : ''}attachment" class="usa-hint usa-file-input" type="file" name="practice[practice_${area}_attributes][RANDOM_NUMBER_OR_SOMETHING_${sType}${resource_type ? '_' + resource_type : ''}][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" />
                     `);
             } else if (ele.type === 'file' && sType === 'image') {
                 $(ele)

--- a/app/assets/javascripts/replies.es6
+++ b/app/assets/javascripts/replies.es6
@@ -38,7 +38,6 @@ $(document).on('turbolinks:load', () => {
 
             const numReplies = target.data('number-replies');
             const repliesText = numReplies === 1 ? 'reply' : 'replies';
-            console.log('container hidden', containerHidden);
             if (!containerHidden) {
                 target.text(`Show ${numReplies} ${repliesText}`);
             } else {

--- a/app/assets/stylesheets/dm/pages/_practice.scss
+++ b/app/assets/stylesheets/dm/pages/_practice.scss
@@ -1154,6 +1154,10 @@ li.small-disc:before {
     width: 1px;
     height: 1px;
   }
+
+  .implementation-resource-label {
+    margin-top: 16px !important;
+  }
 }
 
 // About

--- a/app/assets/stylesheets/dm/pages/_practice.scss
+++ b/app/assets/stylesheets/dm/pages/_practice.scss
@@ -852,6 +852,7 @@
   width: 1px;
   height: 1px;
 }
+
 .pe-continue{
   width: 125px;
 }
@@ -1145,6 +1146,13 @@ li.small-disc:before {
   #dm-add-link-risk-mitigation {
     position: absolute;
     bottom: 0px;
+  }
+
+  .implementation-radio {
+    left: 27px !important;
+    top: 10px;
+    width: 1px;
+    height: 1px;
   }
 }
 

--- a/app/assets/stylesheets/dm/pages/_practice.scss
+++ b/app/assets/stylesheets/dm/pages/_practice.scss
@@ -1075,31 +1075,8 @@ li.small-disc:before {
     }
   }
 
-  .overview-input-error {
-    border-left-width: 0.25rem !important;
-    border-left-color: #b50909 !important;
-    border-left-style: solid !important;
-    padding-left: 1rem !important;
-    position: relative !important;
-  }
-
-  .overview-attachment-input-target-error {
-    border-color: #b50909 !important;
-    border-width: 2px !important;
-  }
-
-  .overview-text-input-error {
-    border-width: 0.25rem !important;
-    border-color: #b50909 !important;
-    border-style: solid !important;
-  }
-
   .overview-resource-label {
     margin-top: 16px !important;
-  }
-
-  .usa-label--error {
-    margin-top: 1.5rem !important;
   }
 
   .overview-problem-statement-label + span, .overview-solution-statement-label + span, .overview-results-statement-label + span {
@@ -1163,4 +1140,28 @@ li.small-disc:before {
 // About
 .origin-story-textarea {
   resize: none;
+}
+
+// Cross-section styles
+.input-error {
+  border-left-width: 0.25rem !important;
+  border-left-color: #b50909 !important;
+  border-left-style: solid !important;
+  padding-left: 1rem !important;
+  position: relative !important;
+}
+
+.attachment-input-target-error {
+  border-color: #b50909 !important;
+  border-width: 2px !important;
+}
+
+.text-input-error {
+  border-width: 0.25rem !important;
+  border-color: #b50909 !important;
+  border-style: solid !important;
+}
+
+.usa-label--error {
+  margin-top: 1.5rem !important;
 }

--- a/app/assets/stylesheets/dm_uswds/theme/_uswds-theme-custom-styles.scss
+++ b/app/assets/stylesheets/dm_uswds/theme/_uswds-theme-custom-styles.scss
@@ -317,3 +317,8 @@ p {
     box-shadow: inset 0 0 0 2px white, inset 0 0 0 1rem $dm-color-blue-70v, 0 0 0 2px $dm-color-blue-70v;
   }
 }
+
+// File input choose text
+.usa-file-input__choose {
+  color: $dm-color-blue-50v !important;
+}

--- a/app/services/save_practice_service.rb
+++ b/app/services/save_practice_service.rb
@@ -44,15 +44,15 @@ class SavePracticeService
       end
 
       updated = @practice.update(@practice_params)
-    rescue_method(:update_practice_partner_practices)
-    rescue_method(:update_department_practices)
-    rescue_method(:remove_attachments)
-    rescue_method(:manipulate_avatars)
-    rescue_method(:remove_main_display_image)
-    rescue_method(:crop_main_display_image)
-    rescue_method(:update_initiating_facility)
-    rescue_method(:update_practice_awards)
-    rescue_method(:update_category_practices)
+      rescue_method(:update_practice_partner_practices)
+      rescue_method(:update_department_practices)
+      rescue_method(:remove_attachments)
+      rescue_method(:manipulate_avatars)
+      rescue_method(:remove_main_display_image)
+      rescue_method(:crop_main_display_image)
+      rescue_method(:update_initiating_facility)
+      rescue_method(:update_practice_awards)
+      rescue_method(:update_category_practices)
       rescue_method(:crop_resource_images)
       updated
     rescue => e
@@ -304,6 +304,9 @@ class SavePracticeService
   def process_practice_resources_params
     PracticeResource.media_types.each do |rt|
       @practice_params['practice_resources_attributes']&.delete('RANDOM_NUMBER_OR_SOMETHING_' + rt[0])
+      @practice_params['practice_resources_attributes']&.delete('RANDOM_NUMBER_OR_SOMETHING_' + rt[0] + '_core')
+      @practice_params['practice_resources_attributes']&.delete('RANDOM_NUMBER_OR_SOMETHING_' + rt[0] + '_optional')
+      @practice_params['practice_resources_attributes']&.delete('RANDOM_NUMBER_OR_SOMETHING_' + rt[0] + '_support')
     end
   end
 

--- a/app/views/commontator/comments/create.js.erb
+++ b/app/views/commontator/comments/create.js.erb
@@ -85,7 +85,6 @@ $('#practice-comment-label').text('<%= @comment.thread.comments.count == 1 ? 'co
 
           var repliesText = numReplies === 1 ? numReplies + ' reply' : numReplies + ' replies';
 
-          console.log('In here')
           $('#comments-show-hide-button-<%= @comment.parent_id %>').text('Hide ' + repliesText);
       }
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -30,7 +30,7 @@
         <div class="homepage-featured-section-container height-auto position-relative margin-bottom-3 desktop:margin-bottom-0 padding-right-4 desktop:padding-right-0">
           <div class="grid-row desktop:margin-right-2">
             <div class="grid-col-12 desktop:grid-col-8">
-              <%= link_to '/covid-19', class: 'dm-internal-link  homepage-featured-link' do %>
+              <%= link_to '/covid-19', class: 'dm-internal-link homepage-featured-link' do %>
                 <h2 class="font-sans-xl">COVID-19<span class="fas fa-angle-right margin-left-105"></span></h2>
               <% end %>
               <p class="line-height-sans-505 font-sans-sm">
@@ -38,7 +38,7 @@
                 We have assembled a group of practices for frontline staff and administrators responding to the changing
                 medical landscape.
               </p>
-              <%= link_to 'See more', '/covid-19', class: 'usa-button usa-button--outline' %>
+              <%= link_to 'See more', '/covid-19', class: 'usa-button--outline dm-btn-base' %>
             </div>
             <div class="grid-col-fill text-center dm-virus-image-container">
               <i class="fas fa-viruses fa-9x text-primary-darker"></i>
@@ -50,14 +50,14 @@
         <div class="homepage-featured-section-container height-full dm-primary-5v-background position-relative padding-right-4 desktop:padding-right-0">
           <div class="grid-row">
             <div class="grid-col-12">
-              <%= link_to '/diffusion-map', class: 'dm-internal-link  homepage-featured-link' do %>
+              <%= link_to '/diffusion-map', class: 'dm-internal-link homepage-featured-link' do %>
                 <h2 class="font-sans-xl">Diffusion map<span class="fas fa-angle-right margin-left-105"></span></h2>
               <% end %>
               <p class="line-height-sans-505 font-sans-sm">
                 See practices mapped out by location.
               </p>
               <div class="dm-diffusion-map-more">
-                <%= link_to 'See more', '/diffusion-map', class: 'usa-button usa-button--outline' %>
+                <%= link_to 'See more', '/diffusion-map', class: 'usa-button--outline dm-btn-base' %>
               </div>
             </div>
           </div>

--- a/app/views/practices/_practice_editor_sidenav.html.erb
+++ b/app/views/practices/_practice_editor_sidenav.html.erb
@@ -3,25 +3,53 @@
 
           <ul id="dm-tabnav" class="usa-sidenav dm-tabnav">
               <li class="usa-sidenav__item">
-                <%= link_to 'Instructions', practice_instructions_path(@practice), class: "#{'active' if current_page?( practice_instructions_path(@practice))} width-full dm-tab" %>
+                <% if current_page?(practice_instructions_path(@practice)) %>
+                  <a href="#" onclick="return false" class="active width-full dm-tab">Instructions</a>
+                <% else %>
+                  <%= link_to 'Instructions', practice_instructions_path(@practice), class: "#{'active' if current_page?( practice_instructions_path(@practice))} width-full dm-tab" %>
+                <% end %>
               </li>
               <li class="usa-sidenav__item">
+                <% if current_page?(practice_introduction_path(@practice)) %>
+                  <a href="#" onclick="return false" class="active width-full dm-tab">Introduction</a>
+                <% else %>
                   <%= link_to 'Introduction', practice_introduction_path(@practice), class: "#{'active' if current_page?( practice_introduction_path(@practice))} dm-tab" %>
+                <% end %>
               </li>
               <li class="usa-sidenav__item">
+                <% if current_page?(practice_adoptions_path(@practice)) %>
+                  <a href="#" onclick="return false" class="active width-full dm-tab">Adoptions</a>
+                <% else %>
                   <%= link_to 'Adoptions', practice_adoptions_path(@practice), class: "#{'active' if current_page?( practice_adoptions_path(@practice))} width-full dm-tab" %>
+                <% end %>
               </li>
               <li class="usa-sidenav__item">
+                <% if current_page?(practice_overview_path(@practice)) %>
+                  <a href="#" onclick="return false" class="active width-full dm-tab">Overview</a>
+                <% else %>
                   <%= link_to 'Overview', practice_overview_path(@practice), class: "#{'active' if current_page?( practice_overview_path(@practice))} width-full dm-tab" %>
+                <% end %>
               </li>
             <li class="usa-sidenav__item">
-              <%= link_to 'Implementation', practice_implementation_path(@practice), class: "#{'active' if current_page?( practice_implementation_path(@practice))} width-full dm-tab" %>
+              <% if current_page?(practice_implementation_path(@practice)) %>
+                <a href="#" onclick="return false" class="active width-full dm-tab">Implementation</a>
+                <% else %>
+                <%= link_to 'Implementation', practice_implementation_path(@practice), class: "#{'active' if current_page?( practice_implementation_path(@practice))} width-full dm-tab" %>
+              <% end %>
             </li>
               <li class="usa-sidenav__item">
+                <% if current_page?(practice_contact_path(@practice)) %>
+                  <a href="#" onclick="return false" class="active width-full dm-tab">Contact</a>
+                <% else %>
                   <%= link_to 'Contact', practice_contact_path(@practice), class: "#{'active' if current_page?( practice_contact_path(@practice))} width-full dm-tab" %>
+                <% end %>
               </li>
               <li class="usa-sidenav__item">
-                <%= link_to 'About', practice_about_path(@practice), class: "#{'active' if current_page?( practice_about_path(@practice))} width-full dm-tab" %>
+                <% if current_page?(practice_about_path(@practice)) %>
+                  <a href="#" onclick="return false" class="active width-full dm-tab">About</a>
+                <% else %>
+                  <%= link_to 'About', practice_about_path(@practice), class: "#{'active' if current_page?( practice_about_path(@practice))} width-full dm-tab" %>
+                <% end %>
               </li>
           </ul>
 

--- a/app/views/practices/favorite.js.erb
+++ b/app/views/practices/favorite.js.erb
@@ -9,7 +9,6 @@
 <% end %>
 
 if (results) {
-  console.log('results', results);
   var r = results.find(function(p) {
     return p.item.id === <%= @practice.id %>;
   });

--- a/app/views/practices/form/about.html.erb
+++ b/app/views/practices/form/about.html.erb
@@ -21,7 +21,7 @@
           <%= render 'pii_phi_alert' %>
         </div>
         <%= nested_form_for(@practice, html: {multipart: true, style: 'max-width: 100%', class: 'usa-form', id: 'form'}) do |f| %>
-          <fieldset class="usa-fieldset grid-col-10">
+          <fieldset class="usa-fieldset grid-col-11">
             <legend class="usa-sr-only">Practice About Information</legend>
             <div class="margin-bottom-5">
               <div class="practice-editor-rect-svg border-top-05 border-primary-dark"></div>
@@ -37,7 +37,7 @@
                 <p class="text-bold margin-bottom-2 line-height-18px">Team members</p>
                 <p class="line-height-26">Add the names of people who helped start the practice.</p>
               </div>
-              <div class="grid-col-8">
+              <div class="grid-col-7">
                 <div id="about_container" class="position-relative">
                   <ul class="practice-editor-about-ul" id="sortable_va_employees" role="listbox" title="Practice about" aria-label="Practice editor VA employee list">
                     <%= f.fields_for :va_employees, wrapper: false do |vae| %>

--- a/app/views/practices/form/contact.html.erb
+++ b/app/views/practices/form/contact.html.erb
@@ -22,20 +22,20 @@
           <%= render 'pii_phi_alert' %>
         </div>
         <%= nested_form_for(@practice, html: {multipart: true, style: 'max-width: 100%', class: 'usa-form', id: 'form'}) do |f| %>
-          <fieldset class="usa-fieldset grid-col-10">
+          <fieldset class="usa-fieldset grid-col-11">
             <legend class="usa-sr-only">Practice Contact</legend>
             <div class="margin-bottom-5">
               <div class="practice-editor-rect-svg border-top-05 border-primary-dark"></div>
               <h4 class="line-height-18px margin-top-3 font-sans-sm text-bold margin-bottom-2">Email <span class="text-gray-50">(required field)</span></h4>
               <p class="line-height-26 margin-bottom-2">Type the email address dedicated to responding to messages for this practice.</p>
 
-              <div class="grid-col-8 main-practice-email-container">
+              <div class="grid-col-7 main-practice-email-container">
                 <%= f.label :support_network_email, 'Main email address', class: 'usa-label line-height-26 x0-top main-practice-email-label' %>
                 <%= f.text_field :support_network_email, class: 'usa-input practice-input width-tablet main-practice-email-input margin-bottom-2', required: true %>
               </div>
 
               <!-- PracticeEmail form -->
-              <div class="grid-col-8">
+              <div class="grid-col-7">
                 <div id="contact_container" class="position-relative">
                   <ul class="practice-editor-contact-ul" role="listbox" title="Practice contact" aria-label="Practice editor contact list">
                     <%= f.fields_for :practice_emails, wrapper: false do |pe| %>

--- a/app/views/practices/form/implementation.html.erb
+++ b/app/views/practices/form/implementation.html.erb
@@ -31,7 +31,7 @@
         </div>
           <!--        Resources     -->
           <div class="practice-editor-rect-svg border-top-05 border-primary-dark margin-top-5"></div>
-          <div class="margin-bottom-5 margin-top-3">
+          <div class="margin-bottom-5 margin-top-3 grid-col-12">
             <h2 class="font-sans-sm">Core resources list</h2>
             <h3 class="text-normal font-sans-sm line-height-sans-5 margin-top-1">
               Provide a list of the resources another facility would need to implement your practice.
@@ -68,7 +68,7 @@
                 <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {area: 'core_attachment', resource_type: 'core'} %>
                 <%= render partial: "practices/implementation_forms/attachment_link_form", locals: {area: 'core_attachment', resource_type: 'core'} %>
               </div>
-              <div id="display_core_attachment_file" class="grid-col-12">
+              <div id="display_core_attachment_file" class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'core', media_type: 'file').exists? %>
                   <h5 id="core_attachment_file_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">FILES:</h5>
                   <% @practice.practice_resources.where(resource_type: 'core', media_type: 'file').each_with_index do |pr, i| %>
@@ -76,7 +76,7 @@
                   <% end %>
                 <% end %>
               </div>
-              <div id="display_core_attachment_link" class="grid-col-12">
+              <div id="display_core_attachment_link" class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'core', media_type: 'link').exists? %>
                   <h5 id="core_attachment_link_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">LINKS:</h5>
                 <% end %>
@@ -121,7 +121,7 @@
                 <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {area: 'optional_attachment', resource_type: 'optional'} %>
                 <%= render partial: "practices/implementation_forms/attachment_link_form", locals: {area: 'optional_attachment', resource_type: 'optional'} %>
               </div>
-              <div id="display_optional_attachment_file"  class="grid-col-12">
+              <div id="display_optional_attachment_file"  class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'optional', media_type: 'file').exists? %>
                   <h5 id="optional_attachment_file_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">FILES:</h5>
                   <% @practice.practice_resources.where(resource_type: 'optional', media_type: 'file').each_with_index do |pr, i| %>
@@ -129,7 +129,7 @@
                   <% end %>
                 <% end %>
               </div>
-              <div id="display_optional_attachment_link" class="grid-col-12">
+              <div id="display_optional_attachment_link" class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'optional', media_type: 'link').exists? %>
                   <h5 id="optional_attachment_link_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">LINKS:</h5>
                 <% end %>
@@ -174,7 +174,7 @@
                 <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {area: 'support_attachment', resource_type: 'support'} %>
                 <%= render partial: "practices/implementation_forms/attachment_link_form", locals: {area: 'support_attachment', resource_type: 'support'} %>
               </div>
-              <div id="display_support_attachment_file"  class="grid-col-12">
+              <div id="display_support_attachment_file"  class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'support', media_type: 'file').exists? %>
                   <h5 id="support_attachment_file_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">FILES:</h5>
                   <% @practice.practice_resources.where(resource_type: 'support', media_type: 'file').each_with_index do |pr, i| %>
@@ -182,7 +182,7 @@
                   <% end %>
                 <% end %>
               </div>
-              <div id="display_support_attachment_link" class="grid-col-12">
+              <div id="display_support_attachment_link" class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'support', media_type: 'link').exists? %>
                   <h5 id="support_attachment_link_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">LINKS:</h5>
                 <% end %>

--- a/app/views/practices/form/implementation.html.erb
+++ b/app/views/practices/form/implementation.html.erb
@@ -49,7 +49,7 @@
               <div class="usa-radio position-relative grid-col-12">
                 <%= radio_button_tag 'practice_resources[media_type]',
                                      'File', false, onclick: "displayAttachmentForm('core_attachment', 'file');",
-                                     class: 'usa-radio__input initiating-facility-type-radio',
+                                     class: 'usa-radio__input implementation-radio',
                                      id: "core_resource_attachment_file"
                 %>
                 <%= label_tag 'core_resource_file', 'File', class: 'usa-radio__label
@@ -58,7 +58,7 @@
               <div class="usa-radio position-relative grid-col-12">
                 <%= radio_button_tag 'practice_resources[media_type]', 'Link',
                                      false, onclick: "displayAttachmentForm('core_attachment', 'link');",
-                                     class: 'usa-radio__input initiating-facility-type-radio',
+                                     class: 'usa-radio__input implementation-radio',
                                      id: "core_resource_attachment_link"
                 %>
                 <%= label_tag 'core_resource_link', 'Link', class: 'usa-radio__label
@@ -102,7 +102,7 @@
               <div class="usa-radio position-relative grid-col-12">
                 <%= radio_button_tag 'practice_resources[media_type]',
                                      'File', false, onclick: "displayAttachmentForm('optional_attachment', 'file');",
-                                     class: 'usa-radio__input initiating-facility-type-radio',
+                                     class: 'usa-radio__input implementation-radio',
                                      id: "optional_resource_attachment_file"
                 %>
                 <%= label_tag 'optional_resource_file', 'File', class: 'usa-radio__label
@@ -111,7 +111,7 @@
               <div class="usa-radio position-relative grid-col-12">
                 <%= radio_button_tag 'practice_resources[media_type]', 'Link',
                                      false, onclick: "displayAttachmentForm('optional_attachment', 'link');",
-                                     class: 'usa-radio__input initiating-facility-type-radio',
+                                     class: 'usa-radio__input implementation-radio',
                                      id: "optional_resource_attachment_link"
                 %>
                 <%= label_tag 'optional_resource_link', 'Link', class: 'usa-radio__label
@@ -155,7 +155,7 @@
               <div class="usa-radio position-relative grid-col-12">
                 <%= radio_button_tag 'practice_resources[media_type]',
                                      'File', false, onclick: "displayAttachmentForm('support_attachment', 'file');",
-                                     class: 'usa-radio__input initiating-facility-type-radio',
+                                     class: 'usa-radio__input implementation-radio',
                                      id: "support_resource_attachment_file"
                 %>
                 <%= label_tag 'support_resource_file', 'File', class: 'usa-radio__label
@@ -164,7 +164,7 @@
               <div class="usa-radio position-relative grid-col-12">
                 <%= radio_button_tag 'practice_resources[media_type]', 'Link',
                                      false, onclick: "displayAttachmentForm('support_attachment', 'link');",
-                                     class: 'usa-radio__input initiating-facility-type-radio',
+                                     class: 'usa-radio__input implementation-radio',
                                      id: "support_resource_attachment_link"
                 %>
                 <%= label_tag 'support_resource_link', 'Link', class: 'usa-radio__label

--- a/app/views/practices/form/implementation.html.erb
+++ b/app/views/practices/form/implementation.html.erb
@@ -43,7 +43,7 @@
             <div class="practice-editor-rect-svg border-top-05 border-primary-dark margin-top-5 margin-bottom-2"></div>
             <h2 class="font-sans-sm">Core resources attachments</h2>
             <h3 class="text-normal font-sans-sm line-height-sans-5 margin-top-1">
-              Upload any files or attach any links related to support resources.
+              Upload any files or attach any links related to core resources.
             </h3>
             <div class="grid-row grid-gap margin-top-2 margin-bottom-0">
               <div class="usa-radio position-relative grid-col-12">
@@ -96,7 +96,7 @@
             <div class="practice-editor-rect-svg border-top-05 border-primary-dark margin-top-5 margin-bottom-2"></div>
             <h2 class="font-sans-sm">Optional resources attachments</h2>
             <h3 class="text-normal font-sans-sm line-height-sans-5 margin-top-1">
-              Upload any files or attach any links related to support resources.
+              Upload any files or attach any links related to optional resources.
             </h3>
             <div class="grid-row grid-gap margin-top-2 margin-bottom-0">
               <div class="usa-radio position-relative grid-col-12">

--- a/app/views/practices/form/implementation.html.erb
+++ b/app/views/practices/form/implementation.html.erb
@@ -45,7 +45,7 @@
             <h3 class="text-normal font-sans-sm line-height-sans-5 margin-top-1">
               Upload any files or attach any links related to support resources.
             </h3>
-            <div class="grid-row grid-gap margin-top-2 margin-bottom-3">
+            <div class="grid-row grid-gap margin-top-2 margin-bottom-0">
               <div class="usa-radio position-relative grid-col-12">
                 <%= radio_button_tag 'practice_resources[media_type]',
                                      'File', false, onclick: "displayAttachmentForm('core_attachment', 'file');",
@@ -64,13 +64,13 @@
                 <%= label_tag 'core_resource_link', 'Link', class: 'usa-radio__label
                 initiating-facility-type-label line-height-19px x0-bottom', for: "core_resource_attachment_link" %>
               </div>
-              <div id="display_core_attachment_form" class="display_core_attachments_form grid-row grid-col-12 margin-bottom-2">
+              <div id="display_core_attachment_form" class="display_core_attachments_form grid-row grid-col-12 margin-bottom-5">
                 <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {area: 'core_attachment', resource_type: 'core'} %>
                 <%= render partial: "practices/implementation_forms/attachment_link_form", locals: {area: 'core_attachment', resource_type: 'core'} %>
               </div>
               <div id="display_core_attachment_file" class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'core', media_type: 'file').exists? %>
-                  <div id="core_attachment_file_section_text" class="text-bold font-sans-3xs margin-bottom-2 text-ls-1 line-height-15px">FILES:</div>
+                  <h5 id="core_attachment_file_section_text" class="text-bold font-sans-3xs margin-bottom-2 margin-top-0 text-ls-1 line-height-15px">FILES:</h5>
                   <% @practice.practice_resources.where(resource_type: 'core', media_type: 'file').each_with_index do |pr, i| %>
                     <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {resource: pr, placeholder: i, area: 'core_attachment', resource_type: 'core'} %>
                   <% end %>
@@ -78,7 +78,7 @@
               </div>
               <div id="display_core_attachment_link" class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'core', media_type: 'link').exists? %>
-                  <div id="core_attachment_link_section_text" class="text-bold font-sans-3xs margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">LINKS:</div>
+                  <h5 id="core_attachment_link_section_text" class="text-bold font-sans-3xs margin-bottom-2 margin-top-0 font-sans-3xs text-ls-1 line-height-15px">LINKS:</h5>
                 <% end %>
                 <% @practice.practice_resources.where(resource_type: 'core', media_type: 'link').each_with_index do |pr, i| %>
                   <%= render partial: "practices/implementation_forms/attachment_link_form", locals: {resource: pr, placeholder: i, area: 'core_attachment', resource_type: 'core'} %>
@@ -98,7 +98,7 @@
             <h3 class="text-normal font-sans-sm line-height-sans-5 margin-top-1">
               Upload any files or attach any links related to support resources.
             </h3>
-            <div class="grid-row grid-gap margin-top-2 margin-bottom-3">
+            <div class="grid-row grid-gap margin-top-2 margin-bottom-0">
               <div class="usa-radio position-relative grid-col-12">
                 <%= radio_button_tag 'practice_resources[media_type]',
                                      'File', false, onclick: "displayAttachmentForm('optional_attachment', 'file');",
@@ -117,13 +117,13 @@
                 <%= label_tag 'optional_resource_link', 'Link', class: 'usa-radio__label
                 initiating-facility-type-label line-height-19px x0-bottom', for: "optional_resource_attachment_link" %>
               </div>
-              <div id="display_optional_attachment_form" class="display_optional_attachments_form grid-row grid-col-12 margin-bottom-2">
+              <div id="display_optional_attachment_form" class="display_optional_attachments_form grid-row grid-col-12 margin-bottom-5">
                 <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {area: 'optional_attachment', resource_type: 'optional'} %>
                 <%= render partial: "practices/implementation_forms/attachment_link_form", locals: {area: 'optional_attachment', resource_type: 'optional'} %>
               </div>
               <div id="display_optional_attachment_file"  class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'optional', media_type: 'file').exists? %>
-                  <div id="optional_attachment_file_section_text" class="text-bold font-sans-3xs margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">FILES:</div>
+                  <h5 id="optional_attachment_file_section_text" class="text-bold font-sans-3xs margin-bottom-2 margin-top-0 font-sans-3xs text-ls-1 line-height-15px">FILES:</h5>
                   <% @practice.practice_resources.where(resource_type: 'optional', media_type: 'file').each_with_index do |pr, i| %>
                     <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {resource: pr, placeholder: i, area: 'optional_attachment', resource_type: 'optional'} %>
                   <% end %>
@@ -131,7 +131,7 @@
               </div>
               <div id="display_optional_attachment_link" class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'optional', media_type: 'link').exists? %>
-                  <div id="optional_attachment_link_section_text" class="text-bold font-sans-3xs margin-bottom-2 text-ls-1 line-height-15px">LINKS:</div>
+                  <h5 id="optional_attachment_link_section_text" class="text-bold font-sans-3xs margin-bottom-2 margin-top-0 text-ls-1 line-height-15px">LINKS:</h5>
                 <% end %>
                 <% @practice.practice_resources.where(resource_type: 'optional', media_type: 'link').each_with_index do |pr, i| %>
                   <%= render partial: "practices/implementation_forms/attachment_link_form", locals: {resource: pr, placeholder: i, area: 'optional_attachment', resource_type: 'optional'} %>
@@ -170,13 +170,13 @@
                 <%= label_tag 'support_resource_link', 'Link', class: 'usa-radio__label
                 initiating-facility-type-label line-height-19px x0-bottom', for: "support_resource_attachment_link" %>
               </div>
-              <div id="display_support_attachment_form" class="display_support_attachments_form grid-row grid-col-12 margin-bottom-2">
+              <div id="display_support_attachment_form" class="display_support_attachments_form grid-row grid-col-12 margin-bottom-5">
                 <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {area: 'support_attachment', resource_type: 'support'} %>
                 <%= render partial: "practices/implementation_forms/attachment_link_form", locals: {area: 'support_attachment', resource_type: 'support'} %>
               </div>
               <div id="display_support_attachment_file"  class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'support', media_type: 'file').exists? %>
-                  <div id="support_attachment_file_section_text" class="text-bold font-sans-3xs margin-bottom-2 text-ls-1 line-height-15px">FILES:</div>
+                  <h5 id="support_attachment_file_section_text" class="text-bold font-sans-3xs margin-bottom-2 margin-top-0 text-ls-1 line-height-15px">FILES:</h5>
                   <% @practice.practice_resources.where(resource_type: 'support', media_type: 'file').each_with_index do |pr, i| %>
                     <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {resource: pr, placeholder: i, area: 'support_attachment', resource_type: 'support'} %>
                   <% end %>
@@ -184,14 +184,14 @@
               </div>
               <div id="display_support_attachment_link" class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'support', media_type: 'link').exists? %>
-                  <div id="support_attachment_link_section_text" class="text-bold font-sans-3xs margin-bottom-2 text-ls-1 line-height-15px">LINKS:</div>
+                  <h5 id="support_attachment_link_section_text" class="text-bold font-sans-3xs margin-bottom-2 margin-top-0 text-ls-1 line-height-15px">LINKS:</h5>
                 <% end %>
                 <% @practice.practice_resources.where(resource_type: 'support', media_type: 'link').each_with_index do |pr, i| %>
                   <%= render partial: "practices/implementation_forms/attachment_link_form", locals: {resource: pr, placeholder: i, area: 'support_attachment', resource_type: 'support'} %>
                 <% end %>
               </div>
             </div>
-            <div class="practice-editor-rect-svg border-top-05 border-primary-dark margin-top-3"></div>
+            <div class="practice-editor-rect-svg border-top-05 border-primary-dark"></div>
             <%= render partial: 'practices/implementation_forms/risks_and_mitigations', locals: {f: f} %>
           </div>
         <% end %>

--- a/app/views/practices/form/implementation.html.erb
+++ b/app/views/practices/form/implementation.html.erb
@@ -70,7 +70,7 @@
               </div>
               <div id="display_core_attachment_file" class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'core', media_type: 'file').exists? %>
-                  <h5 id="core_attachment_file_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">FILES:</h5>
+                  <div id="core_attachment_file_section_text" class="text-bold font-sans-3xs margin-bottom-2 text-ls-1 line-height-15px">FILES:</div>
                   <% @practice.practice_resources.where(resource_type: 'core', media_type: 'file').each_with_index do |pr, i| %>
                     <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {resource: pr, placeholder: i, area: 'core_attachment', resource_type: 'core'} %>
                   <% end %>
@@ -78,7 +78,7 @@
               </div>
               <div id="display_core_attachment_link" class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'core', media_type: 'link').exists? %>
-                  <h5 id="core_attachment_link_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">LINKS:</h5>
+                  <div id="core_attachment_link_section_text" class="text-bold font-sans-3xs margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">LINKS:</div>
                 <% end %>
                 <% @practice.practice_resources.where(resource_type: 'core', media_type: 'link').each_with_index do |pr, i| %>
                   <%= render partial: "practices/implementation_forms/attachment_link_form", locals: {resource: pr, placeholder: i, area: 'core_attachment', resource_type: 'core'} %>
@@ -123,7 +123,7 @@
               </div>
               <div id="display_optional_attachment_file"  class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'optional', media_type: 'file').exists? %>
-                  <h5 id="optional_attachment_file_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">FILES:</h5>
+                  <div id="optional_attachment_file_section_text" class="text-bold font-sans-3xs margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">FILES:</div>
                   <% @practice.practice_resources.where(resource_type: 'optional', media_type: 'file').each_with_index do |pr, i| %>
                     <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {resource: pr, placeholder: i, area: 'optional_attachment', resource_type: 'optional'} %>
                   <% end %>
@@ -131,7 +131,7 @@
               </div>
               <div id="display_optional_attachment_link" class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'optional', media_type: 'link').exists? %>
-                  <h5 id="optional_attachment_link_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">LINKS:</h5>
+                  <div id="optional_attachment_link_section_text" class="text-bold font-sans-3xs margin-bottom-2 text-ls-1 line-height-15px">LINKS:</div>
                 <% end %>
                 <% @practice.practice_resources.where(resource_type: 'optional', media_type: 'link').each_with_index do |pr, i| %>
                   <%= render partial: "practices/implementation_forms/attachment_link_form", locals: {resource: pr, placeholder: i, area: 'optional_attachment', resource_type: 'optional'} %>
@@ -176,7 +176,7 @@
               </div>
               <div id="display_support_attachment_file"  class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'support', media_type: 'file').exists? %>
-                  <h5 id="support_attachment_file_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">FILES:</h5>
+                  <div id="support_attachment_file_section_text" class="text-bold font-sans-3xs margin-bottom-2 text-ls-1 line-height-15px">FILES:</div>
                   <% @practice.practice_resources.where(resource_type: 'support', media_type: 'file').each_with_index do |pr, i| %>
                     <%= render partial: "practices/implementation_forms/attachment_file_form", locals: {resource: pr, placeholder: i, area: 'support_attachment', resource_type: 'support'} %>
                   <% end %>
@@ -184,7 +184,7 @@
               </div>
               <div id="display_support_attachment_link" class="grid-col-11">
                 <% if @practice.practice_resources.where(resource_type: 'support', media_type: 'link').exists? %>
-                  <h5 id="support_attachment_link_section_text" class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">LINKS:</h5>
+                  <div id="support_attachment_link_section_text" class="text-bold font-sans-3xs margin-bottom-2 text-ls-1 line-height-15px">LINKS:</div>
                 <% end %>
                 <% @practice.practice_resources.where(resource_type: 'support', media_type: 'link').each_with_index do |pr, i| %>
                   <%= render partial: "practices/implementation_forms/attachment_link_form", locals: {resource: pr, placeholder: i, area: 'support_attachment', resource_type: 'support'} %>

--- a/app/views/practices/form/overview.html.erb
+++ b/app/views/practices/form/overview.html.erb
@@ -27,7 +27,7 @@
           <fieldset class="usa-fieldset grid-col-11">
             <legend class="usa-sr-only">Practice Overview</legend>
             <!-- PROBLEM section -->
-            <div id="problem_section grid-col-12">
+            <div id="problem_section" class="grid-col-12">
               <div class="practice-editor-rect-svg border-top-05 border-primary-dark"></div>
               <div class="margin-bottom-5 margin-top-3">
                 <%= label_tag 'practice_overview_problem', 'Problem statement', class: 'usa-label text-bold display-inline overview-problem-statement-label' %><span class="text-gray-50 text-bold line-height-18px"> (required field)</span>
@@ -120,7 +120,7 @@
             </div>
 
             <!-- SOLUTION section -->
-            <div id="solution_section grid-col-12">
+            <div id="solution_section" class="grid-col-12">
               <div class="practice-editor-rect-svg border-top-05 border-primary-dark margin-top-5"></div>
               <div class="margin-bottom-5 margin-top-3">
                 <%= label_tag 'practice_overview_solution', 'Solution statement', class: 'usa-label margin-0 text-bold display-inline overview-solution-statement-label' %><span class="text-gray-50 text-bold"> (required field)</span>
@@ -215,7 +215,7 @@
             </div>
 
             <!-- RESULTS section -->
-            <div id="results_section">
+            <div id="results_section" class="grid-col-12">
               <div class="practice-editor-rect-svg border-top-05 border-primary-dark margin-top-5"></div>
               <div class="margin-bottom-5 margin-top-3">
                 <%= label_tag 'practice_overview_results', 'Results statement', class: 'usa-label margin-0 text-bold display-inline overview-results-statement-label' %><span class="text-gray-50 text-bold"> (required field)</span>

--- a/app/views/practices/form/overview.html.erb
+++ b/app/views/practices/form/overview.html.erb
@@ -87,7 +87,7 @@
               </div>
               <div id="display_problem_resources_image">
                 <% if @practice.practice_problem_resources.where(resource_type: 'image').exists? %>
-                  <div id="problem_resources_image_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Images:</div>
+                  <h5 id="problem_resources_image_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Images:</h5>
                   <% @practice.practice_problem_resources.where(resource_type: 'image').each_with_index do |pr, i| %>
                     <%= render partial: "practices/overview_forms/image_form", locals: {resource: pr, placeholder: i, area: 'problem_resources'} %>
                   <% end %>
@@ -95,7 +95,7 @@
               </div>
               <div id="display_problem_resources_video">
                 <% if @practice.practice_problem_resources.where(resource_type: 'video').exists? %>
-                  <div id="problem_resources_video_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Videos:</div>
+                  <h5 id="problem_resources_video_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Videos:</h5>
                 <% end %>
                 <% @practice.practice_problem_resources.where(resource_type: 'video').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/video_form", locals: {resource: pr, placeholder: i, area: 'problem_resources'} %>
@@ -103,7 +103,7 @@
               </div>
               <div id="display_problem_resources_file">
                 <% if @practice.practice_problem_resources.where(resource_type: 'file').exists? %>
-                  <div id="problem_resources_file_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</div>
+                  <h5 id="problem_resources_file_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</h5>
                 <% end %>
                 <% @practice.practice_problem_resources.where(resource_type: 'file').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/file_form", locals: {resource: pr, placeholder: i, area: 'problem_resources'} %>
@@ -111,7 +111,7 @@
               </div>
               <div id="display_problem_resources_link">
                 <% if @practice.practice_problem_resources.where(resource_type: 'link').exists? %>
-                  <div id="problem_resources_link_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Links:</div>
+                  <h5 id="problem_resources_link_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Links:</h5>
                 <% end %>
                 <% @practice.practice_problem_resources.where(resource_type: 'link').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/link_form", locals: {resource: pr, placeholder: i, area: 'problem_resources'} %>
@@ -134,7 +134,7 @@
                   Attach any additional images, videos, files or links related to the solution implemented for your practice.
                 </p>
               </div>
-              <div class="grid-row grid-gap margin-bottom-3">
+              <div class="grid-row grid-gap margin-bottom-5">
                 <div class="usa-radio position-relative grid-col-12">
                   <%= radio_button_tag 'practice_solution_resources[resource_type]',
                                        'Image',
@@ -182,7 +182,7 @@
               </div>
               <div id="display_solution_resources_image">
                 <% if @practice.practice_solution_resources.where(resource_type: 'image').exists? %>
-                  <div id="solution_resources_image_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Images:</div>
+                  <h5 id="solution_resources_image_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Images:</h5>
                   <% @practice.practice_solution_resources.where(resource_type: 'image').each_with_index do |pr, i| %>
                     <%= render partial: "practices/overview_forms/image_form", locals: {resource: pr, placeholder: i, area: 'solution_resources'} %>
                   <% end %>
@@ -190,7 +190,7 @@
               </div>
               <div id="display_solution_resources_video">
                 <% if @practice.practice_solution_resources.where(resource_type: 'video').exists? %>
-                  <div id="solution_resources_video_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Videos:</div>
+                  <h5 id="solution_resources_video_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Videos:</h5>
                 <% end %>
                 <% @practice.practice_solution_resources.where(resource_type: 'video').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/video_form", locals: {resource: pr, placeholder: i, area: 'solution_resources'} %>
@@ -198,7 +198,7 @@
               </div>
               <div id="display_solution_resources_file">
                 <% if @practice.practice_solution_resources.where(resource_type: 'file').exists? %>
-                  <div id="solution_resources_file_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</div>
+                  <h5 id="solution_resources_file_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</h5>
                 <% end %>
                 <% @practice.practice_solution_resources.where(resource_type: 'file').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/file_form", locals: {resource: pr, placeholder: i, area: 'solution_resources'} %>
@@ -206,7 +206,7 @@
               </div>
               <div id="display_solution_resources_link">
                 <% if @practice.practice_solution_resources.where(resource_type: 'link').exists? %>
-                  <div id="solution_resources_link_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Links:</div>
+                  <h5 id="solution_resources_link_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Links:</h5>
                 <% end %>
                 <% @practice.practice_solution_resources.where(resource_type: 'link').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/link_form", locals: {resource: pr, placeholder: i, area: 'solution_resources'} %>
@@ -229,7 +229,7 @@
                   Attach any additional images, videos, files or links relevant to your results statement.
                 </p>
               </div>
-              <div class="grid-row grid-gap margin-bottom-3">
+              <div class="grid-row grid-gap margin-bottom-5">
                 <div class="usa-radio position-relative grid-col-12">
                   <%= radio_button_tag 'practice_results_resources[resource_type]',
                                        'Image',
@@ -277,7 +277,7 @@
               </div>
               <div id="display_results_resources_image">
                 <% if @practice.practice_results_resources.where(resource_type: 'image').exists? %>
-                  <div id="results_resources_image_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Images:</div>
+                  <h5 id="results_resources_image_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Images:</h5>
                   <% @practice.practice_results_resources.where(resource_type: 'image').each_with_index do |pr, i| %>
                     <%= render partial: "practices/overview_forms/image_form", locals: {resource: pr, placeholder: i, area: 'results_resources'} %>
                   <% end %>
@@ -285,7 +285,7 @@
               </div>
               <div id="display_results_resources_video">
                 <% if @practice.practice_results_resources.where(resource_type: 'video').exists? %>
-                  <div id="results_resources_video_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Videos:</div>
+                  <h5 id="results_resources_video_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Videos:</h5>
                 <% end %>
                 <% @practice.practice_results_resources.where(resource_type: 'video').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/video_form", locals: {resource: pr, placeholder: i, area: 'results_resources'} %>
@@ -293,7 +293,7 @@
               </div>
               <div id="display_results_resources_file">
                 <% if @practice.practice_results_resources.where(resource_type: 'file').exists? %>
-                  <div id="results_resources_file_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</div>
+                  <h5 id="results_resources_file_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</h5>
                 <% end %>
                 <% @practice.practice_results_resources.where(resource_type: 'file').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/file_form", locals: {resource: pr, placeholder: i, area: 'results_resources'} %>
@@ -301,7 +301,7 @@
               </div>
               <div id="display_results_resources_link">
                 <% if @practice.practice_results_resources.where(resource_type: 'link').exists? %>
-                  <div id="results_resources_link_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Links:</div>
+                  <h5 id="results_resources_link_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Links:</h5>
                 <% end %>
                 <% @practice.practice_results_resources.where(resource_type: 'link').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/link_form", locals: {resource: pr, placeholder: i, area: 'results_resources'} %>
@@ -431,7 +431,7 @@
               </div>
               <div id="display_multimedia_image">
                 <% if @practice.practice_multimedia.where(resource_type: 'image').exists? %>
-                  <h5 class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">IMAGES:</h5>
+                  <h5 id="multimedia_image_section_text" class="text-bold margin-bottom-2 margin-top-0 font-sans-3xs text-ls-1 line-height-15px">IMAGES:</h5>
                   <% @practice.practice_multimedia.where(resource_type: 'image').each_with_index do |pr, i| %>
                     <%= render partial: "practices/overview_forms/image_form", locals: {resource: pr, placeholder: i, area: 'multimedia'} %>
                   <% end %>
@@ -439,7 +439,7 @@
               </div>
               <div id="display_multimedia_video">
                 <% if @practice.practice_multimedia.where(resource_type: 'video').exists? %>
-                  <h5 class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">VIDEOS:</h5>
+                  <h5 id="multimedia_video_section_text" class="text-bold margin-bottom-2 margin-top-0 font-sans-3xs text-ls-1 line-height-15px">VIDEOS:</h5>
                 <% end %>
                 <% @practice.practice_multimedia.where(resource_type: 'video').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/video_form", locals: {resource: pr, placeholder: i, area: 'multimedia'} %>

--- a/app/views/practices/form/overview.html.erb
+++ b/app/views/practices/form/overview.html.erb
@@ -24,10 +24,10 @@
           <%= render 'pii_phi_alert' %>
         </div>
         <%= nested_form_for(@practice, html: {multipart: true, style: 'max-width: 100%', class: 'usa-form', id: 'form'}) do |f| %>
-          <fieldset class="usa-fieldset grid-col-10">
+          <fieldset class="usa-fieldset grid-col-11">
             <legend class="usa-sr-only">Practice Overview</legend>
             <!-- PROBLEM section -->
-            <div id="problem_section">
+            <div id="problem_section grid-col-12">
               <div class="practice-editor-rect-svg border-top-05 border-primary-dark"></div>
               <div class="margin-bottom-5 margin-top-3">
                 <%= label_tag 'practice_overview_problem', 'Problem statement', class: 'usa-label text-bold display-inline overview-problem-statement-label' %><span class="text-gray-50 text-bold line-height-18px"> (required field)</span>
@@ -78,7 +78,7 @@
                   <%= label_tag 'practice_problem_link', 'Link', class: 'usa-radio__label
                 initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_problem_link" %>
                 </div>
-                <div id="display_problem_resources_form" class="display_problem_form">
+                <div id="display_problem_resources_form" class="display_problem_form grid-col-12">
                     <%= render partial: "practices/overview_forms/image_form", locals: {area: 'problem_resources'} %>
                     <%= render partial: "practices/overview_forms/video_form", locals: {area: 'problem_resources'} %>
                     <%= render partial: "practices/overview_forms/file_form", locals: {area: 'problem_resources'} %>
@@ -101,7 +101,7 @@
                   <%= render partial: "practices/overview_forms/video_form", locals: {resource: pr, placeholder: i, area: 'problem_resources'} %>
                 <% end %>
               </div>
-              <div id="display_problem_resources_file">
+              <div id="display_problem_resources_file grid-row">
                 <% if @practice.practice_problem_resources.where(resource_type: 'file').exists? %>
                   <h5 id="problem_resources_file_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</h5>
                 <% end %>
@@ -120,7 +120,7 @@
             </div>
 
             <!-- SOLUTION section -->
-            <div id="solution_section">
+            <div id="solution_section grid-col-12">
               <div class="practice-editor-rect-svg border-top-05 border-primary-dark margin-top-5"></div>
               <div class="margin-bottom-5 margin-top-3">
                 <%= label_tag 'practice_overview_solution', 'Solution statement', class: 'usa-label margin-0 text-bold display-inline overview-solution-statement-label' %><span class="text-gray-50 text-bold"> (required field)</span>
@@ -173,7 +173,7 @@
                   <%= label_tag 'practice_solution_link', 'Link', class: 'usa-radio__label
                 initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_solution_link" %>
                 </div>
-                <div id="display_solution_resources_form" class="display_problem_form">
+                <div id="display_solution_resources_form" class="display_problem_form grid-col-12">
                     <%= render partial: "practices/overview_forms/image_form", locals: {area: 'solution_resources'} %>
                     <%= render partial: "practices/overview_forms/video_form", locals: {area: 'solution_resources'} %>
                     <%= render partial: "practices/overview_forms/file_form", locals: {area: 'solution_resources'} %>
@@ -268,7 +268,7 @@
                   <%= label_tag 'practice_results_link', 'Link', class: 'usa-radio__label
                 initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_results_link" %>
                 </div>
-                <div id="display_results_resources_form" class="display_problem_form">
+                <div id="display_results_resources_form" class="display_problem_form grid-col-12">
                     <%= render partial: "practices/overview_forms/image_form", locals: {area: 'results_resources'} %>
                     <%= render partial: "practices/overview_forms/video_form", locals: {area: 'results_resources'} %>
                     <%= render partial: "practices/overview_forms/file_form", locals: {area: 'results_resources'} %>
@@ -424,14 +424,14 @@
                   <%= label_tag 'practice_multimedia_video', 'Video', class: 'usa-radio__label
                 initiating-facility-type-label line-height-19px margin-bottom-0 margin-top-105', for: "practice_multimedia_video" %>
                 </div>
-                <div id="display_multimedia_form" class="display_problem_form">
+                <div id="display_multimedia_form" class="display_problem_form grid-col-12">
                   <%= render partial: "practices/overview_forms/image_form", locals: {area: 'multimedia'} %>
                   <%= render partial: "practices/overview_forms/video_form", locals: {area: 'multimedia'} %>
                 </div>
               </div>
               <div id="display_multimedia_image">
                 <% if @practice.practice_multimedia.where(resource_type: 'image').exists? %>
-                  <div class="text-bold margin-bottom-2">IMAGES:</div>
+                  <h5 class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">IMAGES:</h5>
                   <% @practice.practice_multimedia.where(resource_type: 'image').each_with_index do |pr, i| %>
                     <%= render partial: "practices/overview_forms/image_form", locals: {resource: pr, placeholder: i, area: 'multimedia'} %>
                   <% end %>
@@ -439,7 +439,7 @@
               </div>
               <div id="display_multimedia_video">
                 <% if @practice.practice_multimedia.where(resource_type: 'video').exists? %>
-                  <div class="text-bold margin-bottom-2">VIDEOS:</div>
+                  <h5 class="text-bold margin-bottom-2 font-sans-3xs text-ls-1 line-height-15px">VIDEOS:</h5>
                 <% end %>
                 <% @practice.practice_multimedia.where(resource_type: 'video').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/video_form", locals: {resource: pr, placeholder: i, area: 'multimedia'} %>

--- a/app/views/practices/form/overview.html.erb
+++ b/app/views/practices/form/overview.html.erb
@@ -87,7 +87,7 @@
               </div>
               <div id="display_problem_resources_image">
                 <% if @practice.practice_problem_resources.where(resource_type: 'image').exists? %>
-                  <h5 id="problem_resources_image_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Images:</h5>
+                  <div id="problem_resources_image_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Images:</div>
                   <% @practice.practice_problem_resources.where(resource_type: 'image').each_with_index do |pr, i| %>
                     <%= render partial: "practices/overview_forms/image_form", locals: {resource: pr, placeholder: i, area: 'problem_resources'} %>
                   <% end %>
@@ -95,7 +95,7 @@
               </div>
               <div id="display_problem_resources_video">
                 <% if @practice.practice_problem_resources.where(resource_type: 'video').exists? %>
-                  <h5 id="problem_resources_video_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Videos:</h5>
+                  <div id="problem_resources_video_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Videos:</div>
                 <% end %>
                 <% @practice.practice_problem_resources.where(resource_type: 'video').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/video_form", locals: {resource: pr, placeholder: i, area: 'problem_resources'} %>
@@ -103,7 +103,7 @@
               </div>
               <div id="display_problem_resources_file grid-row">
                 <% if @practice.practice_problem_resources.where(resource_type: 'file').exists? %>
-                  <h5 id="problem_resources_file_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</h5>
+                  <div id="problem_resources_file_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</div>
                 <% end %>
                 <% @practice.practice_problem_resources.where(resource_type: 'file').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/file_form", locals: {resource: pr, placeholder: i, area: 'problem_resources'} %>
@@ -111,7 +111,7 @@
               </div>
               <div id="display_problem_resources_link">
                 <% if @practice.practice_problem_resources.where(resource_type: 'link').exists? %>
-                  <h5 id="problem_resources_link_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Links:</h5>
+                  <div id="problem_resources_link_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Links:</div>
                 <% end %>
                 <% @practice.practice_problem_resources.where(resource_type: 'link').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/link_form", locals: {resource: pr, placeholder: i, area: 'problem_resources'} %>
@@ -182,7 +182,7 @@
               </div>
               <div id="display_solution_resources_image">
                 <% if @practice.practice_solution_resources.where(resource_type: 'image').exists? %>
-                  <h5 id="solution_resources_image_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Images:</h5>
+                  <div id="solution_resources_image_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Images:</div>
                   <% @practice.practice_solution_resources.where(resource_type: 'image').each_with_index do |pr, i| %>
                     <%= render partial: "practices/overview_forms/image_form", locals: {resource: pr, placeholder: i, area: 'solution_resources'} %>
                   <% end %>
@@ -190,7 +190,7 @@
               </div>
               <div id="display_solution_resources_video">
                 <% if @practice.practice_solution_resources.where(resource_type: 'video').exists? %>
-                  <h5 id="solution_resources_video_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Videos:</h5>
+                  <div id="solution_resources_video_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Videos:</div>
                 <% end %>
                 <% @practice.practice_solution_resources.where(resource_type: 'video').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/video_form", locals: {resource: pr, placeholder: i, area: 'solution_resources'} %>
@@ -198,7 +198,7 @@
               </div>
               <div id="display_solution_resources_file">
                 <% if @practice.practice_solution_resources.where(resource_type: 'file').exists? %>
-                  <h5 id="solution_resources_file_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</h5>
+                  <div id="solution_resources_file_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</div>
                 <% end %>
                 <% @practice.practice_solution_resources.where(resource_type: 'file').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/file_form", locals: {resource: pr, placeholder: i, area: 'solution_resources'} %>
@@ -206,7 +206,7 @@
               </div>
               <div id="display_solution_resources_link">
                 <% if @practice.practice_solution_resources.where(resource_type: 'link').exists? %>
-                  <h5 id="solution_resources_link_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Links:</h5>
+                  <div id="solution_resources_link_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Links:</div>
                 <% end %>
                 <% @practice.practice_solution_resources.where(resource_type: 'link').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/link_form", locals: {resource: pr, placeholder: i, area: 'solution_resources'} %>
@@ -277,7 +277,7 @@
               </div>
               <div id="display_results_resources_image">
                 <% if @practice.practice_results_resources.where(resource_type: 'image').exists? %>
-                  <h5 id="results_resources_image_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Images:</h5>
+                  <div id="results_resources_image_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Images:</div>
                   <% @practice.practice_results_resources.where(resource_type: 'image').each_with_index do |pr, i| %>
                     <%= render partial: "practices/overview_forms/image_form", locals: {resource: pr, placeholder: i, area: 'results_resources'} %>
                   <% end %>
@@ -285,7 +285,7 @@
               </div>
               <div id="display_results_resources_video">
                 <% if @practice.practice_results_resources.where(resource_type: 'video').exists? %>
-                  <h5 id="results_resources_video_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Videos:</h5>
+                  <div id="results_resources_video_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Videos:</div>
                 <% end %>
                 <% @practice.practice_results_resources.where(resource_type: 'video').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/video_form", locals: {resource: pr, placeholder: i, area: 'results_resources'} %>
@@ -293,7 +293,7 @@
               </div>
               <div id="display_results_resources_file">
                 <% if @practice.practice_results_resources.where(resource_type: 'file').exists? %>
-                  <h5 id="results_resources_file_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</h5>
+                  <div id="results_resources_file_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Files:</div>
                 <% end %>
                 <% @practice.practice_results_resources.where(resource_type: 'file').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/file_form", locals: {resource: pr, placeholder: i, area: 'results_resources'} %>
@@ -301,7 +301,7 @@
               </div>
               <div id="display_results_resources_link">
                 <% if @practice.practice_results_resources.where(resource_type: 'link').exists? %>
-                  <h5 id="results_resources_link_section_text" class="font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Links:</h5>
+                  <div id="results_resources_link_section_text" class="text-bold font-sans-3xs text-uppercase text-ls-1 line-height-15px margin-bottom-2 margin-top-0">Links:</div>
                 <% end %>
                 <% @practice.practice_results_resources.where(resource_type: 'link').each_with_index do |pr, i| %>
                   <%= render partial: "practices/overview_forms/link_form", locals: {resource: pr, placeholder: i, area: 'results_resources'} %>

--- a/app/views/practices/implementation_forms/_attachment_file_form.html.erb
+++ b/app/views/practices/implementation_forms/_attachment_file_form.html.erb
@@ -23,7 +23,7 @@
           message: 'Please upload a file'
       }
       %>
-      <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>-input-single_<%= placeholder %>" class="usa-file-input usa-hint <%= area %>-file-attachment" type="file" name="practice[practice_resources_attributes][<%= placeholder %>][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" aria-describedby="practice_<%= area %>-input-single_<%= placeholder %>-hint" />
+      <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>-input-single_<%= placeholder %>" class="usa-file-input usa-hint <%= area %>-file-attachment" type="file" name="practice[practice_resources_attributes][<%= placeholder %>][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" />
     </div>
   <% end %>
   <div class="<%= area %>-input-container">

--- a/app/views/practices/implementation_forms/_attachment_file_form.html.erb
+++ b/app/views/practices/implementation_forms/_attachment_file_form.html.erb
@@ -3,7 +3,7 @@
    placeholder = placeholder.to_s + '_file'
    area = area.to_s
 %>
-<div id="<%= area %>_file_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-2" <% end %>>
+<div id="<%= area %>_file_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-2" <% end %> class="grid-col-11">
   <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][media_type]" value="file"/>
   <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][resource_type]" value="<%= area.split('_')[0] %>"/>
   <% if resource&.id  %>
@@ -35,7 +35,7 @@
     }
     %>
 
-    <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.name %>" type="text" name="practice[practice_resources_attributes][<%= placeholder %>][name]" id="practice_<%= area %>_attributes_<%= placeholder %>_name"/>
+    <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-7" value="<%= resource&.name %>" type="text" name="practice[practice_resources_attributes][<%= placeholder %>][name]" id="practice_<%= area %>_attributes_<%= placeholder %>_name"/>
   </div>
   <div class="<%= area %>-input-container">
     <%= label_tag "practice_#{area}_description", 'File description', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_description" %>

--- a/app/views/practices/implementation_forms/_attachment_file_form.html.erb
+++ b/app/views/practices/implementation_forms/_attachment_file_form.html.erb
@@ -1,6 +1,6 @@
 <% resource ||= nil
    placeholder ||= 'RANDOM_NUMBER_OR_SOMETHING'
-   placeholder = placeholder.to_s + '_file'
+   placeholder = "#{placeholder.to_s}_file_#{resource_type}"
    area = area.to_s
 %>
 <div id="<%= area %>_file_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-5" <% end %> class="grid-col-11">
@@ -14,7 +14,7 @@
     <input value="<%= resource&.id %>" type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][id]"/>
   <% else %>
     <div class="grid-col-12 margin-x-auto">
-      <label class="usa-label maxw-full margin-bottom-2 implementation-resource-label" for="practice_<%= area %>-input-single_<%= placeholder %>">
+      <label class="usa-label maxw-full margin-bottom-2 implementation-resource-label" for="practice_<%= area %>_attributes_<%= placeholder %>_attachment">
         Upload a .pdf, .docx, .xlxs, .jpg, .jpeg, or .png file that is less than 32MB.
       </label>
       <%= render partial: 'practices/overview_error_partials/attachment', locals: {
@@ -23,7 +23,7 @@
           message: 'Please upload a file'
       }
       %>
-      <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>-input-single_<%= placeholder %>" class="usa-file-input usa-hint <%= area %>-file-attachment" type="file" name="practice[practice_resources_attributes][<%= placeholder %>][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" />
+      <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>_attributes_<%= placeholder %>_attachment" class="usa-file-input usa-hint <%= area %>-file-attachment" type="file" name="practice[practice_resources_attributes][<%= placeholder %>][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" />
     </div>
   <% end %>
   <div class="<%= area %>-input-container">
@@ -47,5 +47,5 @@
     %>
     <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.description %>"  type="text" name="practice[practice_resources_attributes][<%= placeholder %>][description]" id="practice_<%= area %>_attributes_<%= placeholder %>_description"/>
   </div>
-  <%= render partial: "practices/overview_forms/form_actions", locals: { resource: resource, placeholder: placeholder, area: area, type: 'file', align: 'right', table_name: 'resources' } %>
+  <%= render partial: "practices/overview_forms/form_actions", locals: { resource: resource, placeholder: placeholder, area: area, type: 'file', align: 'right', table_name: 'resources', resource_type: resource_type } %>
 </div>

--- a/app/views/practices/implementation_forms/_attachment_file_form.html.erb
+++ b/app/views/practices/implementation_forms/_attachment_file_form.html.erb
@@ -3,7 +3,7 @@
    placeholder = placeholder.to_s + '_file'
    area = area.to_s
 %>
-<div id="<%= area %>_file_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-2" <% end %> class="grid-col-11">
+<div id="<%= area %>_file_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-5" <% end %> class="grid-col-11">
   <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][media_type]" value="file"/>
   <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][resource_type]" value="<%= area.split('_')[0] %>"/>
   <% if resource&.id  %>
@@ -14,7 +14,7 @@
     <input value="<%= resource&.id %>" type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][id]"/>
   <% else %>
     <div class="grid-col-12 margin-x-auto">
-      <label class="usa-label maxw-full margin-bottom-2 overview-resource-label" for="practice_<%= area %>-input-single_<%= placeholder %>">
+      <label class="usa-label maxw-full margin-bottom-2 implementation-resource-label" for="practice_<%= area %>-input-single_<%= placeholder %>">
         Upload a .pdf, .docx, .xlxs, .jpg, .jpeg, or .png file that is less than 32MB.
       </label>
       <%= render partial: 'practices/overview_error_partials/attachment', locals: {
@@ -27,7 +27,7 @@
     </div>
   <% end %>
   <div class="<%= area %>-input-container">
-    <%= label_tag "practice_#{area}_name", 'File name', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_name" %>
+    <%= label_tag "practice_#{area}_name", 'File name', class: 'usa-label implementation-resource-label', for: "practice_#{area}_attributes_#{placeholder}_name" %>
     <%= render partial: 'practices/overview_error_partials/name', locals: {
         area: area,
         resource_type: 'file',
@@ -38,7 +38,7 @@
     <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-7" value="<%= resource&.name %>" type="text" name="practice[practice_resources_attributes][<%= placeholder %>][name]" id="practice_<%= area %>_attributes_<%= placeholder %>_name"/>
   </div>
   <div class="<%= area %>-input-container">
-    <%= label_tag "practice_#{area}_description", 'File description', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_description" %>
+    <%= label_tag "practice_#{area}_description", 'File description', class: 'usa-label implementation-resource-label', for: "practice_#{area}_attributes_#{placeholder}_description" %>
     <%= render partial: 'practices/overview_error_partials/description', locals: {
         area: area,
         resource_type: 'file',

--- a/app/views/practices/implementation_forms/_attachment_link_form.html.erb
+++ b/app/views/practices/implementation_forms/_attachment_link_form.html.erb
@@ -4,14 +4,14 @@
    area = area.to_s
 %>
 <div class="grid-col-12">
-  <div id="<%= area %>_link_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-2" <% end %> class="grid-col-11">
+  <div id="<%= area %>_link_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-5" <% end %> class="grid-col-11">
     <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][media_type]" value="link"/>
     <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][resource_type]" value="<%= area.split('_')[0] %>"/>
     <% if resource&.id  %>
       <input value="<%= resource&.id %>" type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][id]"/>
     <% end %>
     <div class="<%= area %>-input-container">
-      <%= label_tag "practice_#{area}_link", 'Link (paste the full address)', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_link_url" %>
+      <%= label_tag "practice_#{area}_link", 'Link (paste the full address)', class: 'usa-label implementation-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_link_url" %>
       <%= render partial: 'practices/overview_error_partials/link', locals: {
           area: area,
           resource_type: 'link',
@@ -22,7 +22,7 @@
       <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.link_url %>" type="text" name="practice[practice_resources_attributes][<%= placeholder %>][link_url]" id="practice_<%= area %>_attributes_<%= placeholder %>_link_url"/>
     </div>
     <div class="<%= area %>-input-container">
-      <%= label_tag "practice_#{area}_name", 'Title', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_name" %>
+      <%= label_tag "practice_#{area}_name", 'Title', class: 'usa-label implementation-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_name" %>
       <%= render partial: 'practices/overview_error_partials/name', locals: {
           area: area,
           resource_type: 'link',
@@ -33,7 +33,7 @@
     </div>
 
     <div class="<%= area %>-input-container">
-      <%= label_tag "practice_#{area}_description", 'Description', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_description" %>
+      <%= label_tag "practice_#{area}_description", 'Description', class: 'usa-label implementation-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_description" %>
       <%= render partial: 'practices/overview_error_partials/description', locals: {
           area: area,
           resource_type: 'link',

--- a/app/views/practices/implementation_forms/_attachment_link_form.html.erb
+++ b/app/views/practices/implementation_forms/_attachment_link_form.html.erb
@@ -4,7 +4,7 @@
    area = area.to_s
 %>
 <div class="grid-col-12">
-  <div id="<%= area %>_link_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-2" <% end %>>
+  <div id="<%= area %>_link_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-2" <% end %> class="grid-col-11">
     <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][media_type]" value="link"/>
     <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][resource_type]" value="<%= area.split('_')[0] %>"/>
     <% if resource&.id  %>

--- a/app/views/practices/implementation_forms/_attachment_link_form.html.erb
+++ b/app/views/practices/implementation_forms/_attachment_link_form.html.erb
@@ -3,46 +3,45 @@
    placeholder = placeholder.to_s + '_link'
    area = area.to_s
 %>
-<div class="grid-col-12">
-  <div id="<%= area %>_link_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-2" <% end %> class="grid-col-11">
-    <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][media_type]" value="link"/>
-    <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][resource_type]" value="<%= area.split('_')[0] %>"/>
-    <% if resource&.id  %>
-      <input value="<%= resource&.id %>" type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][id]"/>
-    <% end %>
-    <div class="<%= area %>-input-container">
-      <%= label_tag "practice_#{area}_link", 'Link (paste the full address)', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_link_url" %>
-      <%= render partial: 'practices/overview_error_partials/link', locals: {
+
+<div id="<%= area %>_link_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-5" <% end %> class="grid-col-11">
+  <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][media_type]" value="link"/>
+  <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][resource_type]" value="<%= area.split('_')[0] %>"/>
+  <% if resource&.id  %>
+    <input value="<%= resource&.id %>" type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][id]"/>
+  <% end %>
+  <div class="<%= area %>-input-container">
+    <%= label_tag "practice_#{area}_link", 'Link (paste the full address)', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_link_url" %>
+    <%= render partial: 'practices/overview_error_partials/link', locals: {
+      area: area,
+      resource_type: 'link',
+      message: 'Please enter a valid url/link'
+    }
+    %>
+
+    <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.link_url %>" type="text" name="practice[practice_resources_attributes][<%= placeholder %>][link_url]" id="practice_<%= area %>_attributes_<%= placeholder %>_link_url"/>
+  </div>
+  <div class="<%= area %>-input-container">
+    <%= label_tag "practice_#{area}_name", 'Title', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_name" %>
+    <%= render partial: 'practices/overview_error_partials/name', locals: {
         area: area,
         resource_type: 'link',
-        message: 'Please enter a valid url/link'
-      }
-      %>
-
-      <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.link_url %>" type="text" name="practice[practice_resources_attributes][<%= placeholder %>][link_url]" id="practice_<%= area %>_attributes_<%= placeholder %>_link_url"/>
-    </div>
-    <div class="<%= area %>-input-container">
-      <%= label_tag "practice_#{area}_name", 'Title', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_name" %>
-      <%= render partial: 'practices/overview_error_partials/name', locals: {
-          area: area,
-          resource_type: 'link',
-          message: 'Please enter a link title'
-      }
-      %>
-      <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-6" value="<%= resource&.name %>" type="text" name="practice[practice_resources_attributes][<%= placeholder %>][name]" id="practice_<%= area %>_attributes_<%= placeholder %>_name"/>
-    </div>
-
-    <div class="<%= area %>-input-container">
-      <%= label_tag "practice_#{area}_description", 'Description', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_description" %>
-      <%= render partial: 'practices/overview_error_partials/description', locals: {
-          area: area,
-          resource_type: 'link',
-          message: 'Please enter a link description'
-      }
-      %>
-      <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.description %>" type="text" name="practice[practice_resources_attributes][<%= placeholder %>][description]" id="practice_<%= area %>_attributes_<%= placeholder %>_description"/>
-    </div>
-    <%# action buttons %>
-    <%= render partial: "practices/overview_forms/form_actions", locals: { resource: resource, placeholder: placeholder, area: area, type: 'link', align: 'right', table_name: 'resources' } %>
+        message: 'Please enter a link title'
+    }
+    %>
+    <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-6" value="<%= resource&.name %>" type="text" name="practice[practice_resources_attributes][<%= placeholder %>][name]" id="practice_<%= area %>_attributes_<%= placeholder %>_name"/>
   </div>
+
+  <div class="<%= area %>-input-container">
+    <%= label_tag "practice_#{area}_description", 'Description', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_description" %>
+    <%= render partial: 'practices/overview_error_partials/description', locals: {
+        area: area,
+        resource_type: 'link',
+        message: 'Please enter a link description'
+    }
+    %>
+    <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.description %>" type="text" name="practice[practice_resources_attributes][<%= placeholder %>][description]" id="practice_<%= area %>_attributes_<%= placeholder %>_description"/>
+  </div>
+  <%# action buttons %>
+  <%= render partial: "practices/overview_forms/form_actions", locals: { resource: resource, placeholder: placeholder, area: area, type: 'link', align: 'right', table_name: 'resources' } %>
 </div>

--- a/app/views/practices/implementation_forms/_attachment_link_form.html.erb
+++ b/app/views/practices/implementation_forms/_attachment_link_form.html.erb
@@ -3,25 +3,26 @@
    placeholder = placeholder.to_s + '_link'
    area = area.to_s
 %>
-<div id="<%= area %>_link_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-2" <% end %> class="grid-col-11">
-  <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][media_type]" value="link"/>
-  <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][resource_type]" value="<%= area.split('_')[0] %>"/>
-  <% if resource&.id  %>
-    <input value="<%= resource&.id %>" type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][id]"/>
-  <% end %>
-  <div class="<%= area %>-input-container">
-    <%= label_tag "practice_#{area}_link", 'Link (paste the full address)', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_link_url" %>
-    <%= render partial: 'practices/overview_error_partials/link', locals: {
+<div class="grid-col-12">
+  <div id="<%= area %>_link_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-2" <% end %> class="grid-col-11">
+    <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][media_type]" value="link"/>
+    <input type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][resource_type]" value="<%= area.split('_')[0] %>"/>
+    <% if resource&.id  %>
+      <input value="<%= resource&.id %>" type="hidden" name="practice[practice_resources_attributes][<%= placeholder %>][id]"/>
+    <% end %>
+    <div class="<%= area %>-input-container">
+      <%= label_tag "practice_#{area}_link", 'Link (paste the full address)', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_link_url" %>
+      <%= render partial: 'practices/overview_error_partials/link', locals: {
         area: area,
         resource_type: 'link',
         message: 'Please enter a valid url/link'
-    }
-    %>
+      }
+      %>
 
       <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.link_url %>" type="text" name="practice[practice_resources_attributes][<%= placeholder %>][link_url]" id="practice_<%= area %>_attributes_<%= placeholder %>_link_url"/>
     </div>
     <div class="<%= area %>-input-container">
-      <%= label_tag "practice_#{area}_name", 'Title', class: 'usa-label implementation-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_name" %>
+      <%= label_tag "practice_#{area}_name", 'Title', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_name" %>
       <%= render partial: 'practices/overview_error_partials/name', locals: {
           area: area,
           resource_type: 'link',
@@ -32,7 +33,7 @@
     </div>
 
     <div class="<%= area %>-input-container">
-      <%= label_tag "practice_#{area}_description", 'Description', class: 'usa-label implementation-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_description" %>
+      <%= label_tag "practice_#{area}_description", 'Description', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_link_description" %>
       <%= render partial: 'practices/overview_error_partials/description', locals: {
           area: area,
           resource_type: 'link',

--- a/app/views/practices/introduction_forms/_image_editor.html.erb
+++ b/app/views/practices/introduction_forms/_image_editor.html.erb
@@ -16,9 +16,9 @@
       <p class="usa-alert__body"></p>
     </div>
     <%= form.file_field :main_display_image, class: "dm-cropper-upload-image usa-file-input", accept: 'image/*' %>
-    <div class="dm-cropper-images-container grid-col-6 margin-top-2" data-type="main">
+    <div class="dm-cropper-images-container grid-col-6 margin-top-2">
       <% if practice.main_display_image.present? %>
-        <%= image_tag practice.main_display_image_s3_presigned_url(:original),
+        <%= image_tag practice.main_display_image_s3_presigned_url(),
                       alt: "practice thumbnail for #{practice.name}",
                       class: 'dm-cropper-thumbnail-original display-none' %>
         <%= image_tag practice.main_display_image_s3_presigned_url(:thumb),

--- a/app/views/practices/overview_forms/_file_form.html.erb
+++ b/app/views/practices/overview_forms/_file_form.html.erb
@@ -20,7 +20,7 @@
           message: 'Please upload a file'
       }
       %>
-      <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>-input-single_<%= placeholder %>" class="usa-file-input usa-hint <%= area %>-file-attachment" type="file" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" aria-describedby="practice_<%= area %>-input-single_<%= placeholder %>-hint" />
+      <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>-input-single_<%= placeholder %>" class="usa-file-input usa-hint <%= area %>-file-attachment" type="file" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" />
     </div>
   <% end %>
   <div class="<%= area %>-input-container">

--- a/app/views/practices/overview_forms/_file_form.html.erb
+++ b/app/views/practices/overview_forms/_file_form.html.erb
@@ -4,10 +4,10 @@
    area = area.to_s
 %>
 
-<div id="<%= area %>_file_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-5" <% end %>>
+<div id="<%= area %>_file_form<%= "_#{placeholder}" if resource %>" <% if resource %> class="resource_container margin-bottom-5 grid-col-12" <% end %> class="grid-col-12">
   <input type="hidden" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][resource_type]" value="file"/>
   <% if resource&.id  %>
-    <span class="line-height-26">File: <%= link_to(resource&.attachment&.original_filename, resource&.attachment_s3_presigned_url, target: '_blank')%></span>
+    <span class="line-height-26">File: <%= link_to(resource&.attachment&.original_filename, resource&.attachment_s3_presigned_url, target: '_blank', class: 'dm-external-link')%></span>
     <input value="<%= resource&.id %>" type="hidden" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][id]"/>
   <% else %>
     <div class="grid-col-12 margin-x-auto">
@@ -31,7 +31,7 @@
         message: 'Please enter a file name'
     }
     %>
-    <input <%= resource&.id ? 'required' : '' %> class="usa-input" value="<%= resource&.name %>" type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][name]" id="practice_<%= area %>_attributes_<%= placeholder %>_name" style="width: 393px"/>
+    <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-8" value="<%= resource&.name %>" type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][name]" id="practice_<%= area %>_attributes_<%= placeholder %>_name"/>
   </div>
   <div class="<%= area %>-input-container">
     <%= label_tag "practice_#{area}_description", 'File description', class: 'usa-label overview-resource-label', for: "practice_#{area}_attributes_#{placeholder}_description" %>
@@ -41,7 +41,7 @@
         message: 'Please enter a file description'
     }
     %>
-    <input <%= resource&.id ? 'required' : '' %> class="usa-input" value="<%= resource&.description %>"  type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][description]" id="practice_<%= area %>_attributes_<%= placeholder %>_description" style="width: 643px"/>
+    <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.description %>"  type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][description]" id="practice_<%= area %>_attributes_<%= placeholder %>_description"/>
   </div>
 
   <%# action buttons %>

--- a/app/views/practices/overview_forms/_file_form.html.erb
+++ b/app/views/practices/overview_forms/_file_form.html.erb
@@ -11,7 +11,7 @@
     <input value="<%= resource&.id %>" type="hidden" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][id]"/>
   <% else %>
     <div class="grid-col-12 margin-x-auto">
-      <label class="usa-label maxw-full margin-bottom-2 overview-resource-label" for="practice_<%= area %>-input-single_<%= placeholder %>">
+      <label class="usa-label maxw-full margin-bottom-2 overview-resource-label" for="practice_<%= area %>_<%= placeholder %>">
         Upload a .pdf, .docx, .xlxs, .jpg, .jpeg, or .png file that is less than 32MB.
       </label>
       <%= render partial: 'practices/overview_error_partials/attachment', locals: {
@@ -20,7 +20,7 @@
           message: 'Please upload a file'
       }
       %>
-      <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>-input-single_<%= placeholder %>" class="usa-file-input usa-hint <%= area %>-file-attachment" type="file" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" />
+      <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>_attributes_<%= placeholder %>_attachment" class="usa-file-input usa-hint <%= area %>-file-attachment" type="file" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][attachment]" accept=".pdf,.docx,.xlxs,.jpg,.jpeg,.png" />
     </div>
   <% end %>
   <div class="<%= area %>-input-container">

--- a/app/views/practices/overview_forms/_form_actions.html.erb
+++ b/app/views/practices/overview_forms/_form_actions.html.erb
@@ -4,11 +4,12 @@
    type = type
    align ||= 'right'
    table_name ||= area
+   resource_type ||= ''
 %>
 <% if resource&.id %>
   <div class="grid-col-12 margin-top-2" align="<%= align %>">
     <input type="hidden" value="false" name="practice[practice_<%= table_name %>_attributes][<%= placeholder %>][_destroy]"/>
-    <button type="button" data-area="<%= area %>" data-type="<%= type %>" class="usa-button--unstyled dm-btn-warning line height-26 remove_nested_fields">Delete entry</button>
+    <button type="button" data-area="<%= area %>" data-type="<%= type %>" class="usa-button--unstyled dm-btn-warning line-height-26 remove_nested_fields">Delete entry</button>
   </div>
 <% else %>
   <div class="dm-cancel-add-button-row grid-row margin-top-2 margin-bottom-0">

--- a/app/views/practices/overview_forms/_form_actions.html.erb
+++ b/app/views/practices/overview_forms/_form_actions.html.erb
@@ -8,7 +8,7 @@
 <% if resource&.id %>
   <div class="grid-col-12 margin-top-2" align="<%= align %>">
     <input type="hidden" value="false" name="practice[practice_<%= table_name %>_attributes][<%= placeholder %>][_destroy]"/>
-    <button type="button" data-area="<%= area %>" data-type="<%= type %>"class="usa-button--unstyled dm-btn-warning line height-26 remove_nested_fields">Delete entry</button>
+    <button type="button" data-area="<%= area %>" data-type="<%= type %>" class="usa-button--unstyled dm-btn-warning line height-26 remove_nested_fields">Delete entry</button>
   </div>
 <% else %>
   <div class="dm-cancel-add-button-row grid-row margin-top-2 margin-bottom-0">

--- a/app/views/practices/overview_forms/_form_actions.html.erb
+++ b/app/views/practices/overview_forms/_form_actions.html.erb
@@ -2,7 +2,7 @@
    placeholder = placeholder
    area = area
    type = type
-   align ||= 'left'
+   align ||= 'right'
    table_name ||= area
 %>
 <% if resource&.id %>

--- a/app/views/practices/overview_forms/_image_form.html.erb
+++ b/app/views/practices/overview_forms/_image_form.html.erb
@@ -35,7 +35,7 @@
           }
           %>
           <%# resource attachment %>
-          <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>_<%= placeholder %>" class="dm-cropper-upload-image usa-file-input usa-hint <%= area %>-image-attachment" type="file" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][attachment]" accept=".jpg,.jpeg,.png" />
+          <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>_attributes_<%= placeholder %>" class="dm-cropper-upload-image usa-file-input usa-hint <%= area %>-image-attachment" type="file" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][attachment]" accept=".jpg,.jpeg,.png" />
         </div>
       <% end %>
 

--- a/app/views/practices/overview_forms/_image_form.html.erb
+++ b/app/views/practices/overview_forms/_image_form.html.erb
@@ -20,7 +20,7 @@
       <% } %>
       <% if !resource&.id %>
         <div class="margin-y-1">
-          <label class="usa-label dm-file-upload-label margin-bottom-2 overview-resource-label" for="practice_<%= area %>-input-single_<%= placeholder %>">
+          <label class="usa-label dm-file-upload-label margin-bottom-2 overview-resource-label" for="practice_<%= area %>_<%= placeholder %>">
             Use a high-quality .jpg, .jpeg, or .png file that is less than 32MB. If you want to upload an image that features a Veteran you must have
             <%= link_to 'Form 3203', 'https://vaww.rtp.portal.va.gov/DEAN/IE/DOE/10-3203.pdf', target: '_blank' %>. Waivers must be filled out with the 'External to VA' check box selected.
           </label>
@@ -35,7 +35,7 @@
           }
           %>
           <%# resource attachment %>
-          <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>-input-single_<%= placeholder %>" class="dm-cropper-upload-image usa-file-input usa-hint <%= area %>-image-attachment" type="file" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][attachment]" accept=".jpg,.jpeg,.png" />
+          <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>_<%= placeholder %>" class="dm-cropper-upload-image usa-file-input usa-hint <%= area %>-image-attachment" type="file" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][attachment]" accept=".jpg,.jpeg,.png" />
         </div>
       <% end %>
 

--- a/app/views/practices/overview_forms/_image_form.html.erb
+++ b/app/views/practices/overview_forms/_image_form.html.erb
@@ -35,7 +35,7 @@
           }
           %>
           <%# resource attachment %>
-          <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>-input-single_<%= placeholder %>" class="dm-cropper-upload-image usa-file-input usa-hint <%= area %>-image-attachment" type="file" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][attachment]" accept=".jpg,.jpeg,.png" aria-describedby="practice_<%= area %>-input-single_<%= placeholder %>-hint" />
+          <input <%= resource&.id ? 'required' : '' %> id="practice_<%= area %>-input-single_<%= placeholder %>" class="dm-cropper-upload-image usa-file-input usa-hint <%= area %>-image-attachment" type="file" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][attachment]" accept=".jpg,.jpeg,.png" />
         </div>
       <% end %>
 

--- a/app/views/practices/overview_forms/_link_form.html.erb
+++ b/app/views/practices/overview_forms/_link_form.html.erb
@@ -17,7 +17,7 @@
           message: 'Please enter a valid url/link'
       }
       %>
-      <input <%= resource&.id ? 'required' : '' %> class="usa-input" value="<%= resource&.link_url %>" type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][link_url]" id="practice_<%= area %>_attributes_<%= placeholder %>_link_url" style="width: 643px"/>
+      <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.link_url %>" type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][link_url]" id="practice_<%= area %>_attributes_<%= placeholder %>_link_url"/>
     </div>
 
     <div class="<%= area %>-input-container">
@@ -28,7 +28,7 @@
           message: 'Please enter a link title'
       }
       %>
-      <input <%= resource&.id ? 'required' : '' %> class="usa-input" value="<%= resource&.name %>" type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][name]" id="practice_<%= area %>_attributes_<%= placeholder %>_name" style="width: 393px"/>
+      <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-6" value="<%= resource&.name %>" type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][name]" id="practice_<%= area %>_attributes_<%= placeholder %>_name"/>
     </div>
 
     <div class="<%= area %>-input-container">
@@ -39,7 +39,7 @@
           message: 'Please enter a link description'
       }
       %>
-      <input <%= resource&.id ? 'required' : '' %> class="usa-input" value="<%= resource&.description %>" type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][description]" id="practice_<%= area %>_attributes_<%= placeholder %>_description" style="width: 643px"/>
+      <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.description %>" type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][description]" id="practice_<%= area %>_attributes_<%= placeholder %>_description"/>
     </div>
 
   <%# action buttons %>

--- a/app/views/practices/overview_forms/_video_form.html.erb
+++ b/app/views/practices/overview_forms/_video_form.html.erb
@@ -20,7 +20,7 @@
         message: 'Please enter a valid YouTube url'
     }
     %>
-    <input <%= resource&.id ? 'required' : '' %> class="usa-input" value="<%= resource&.link_url %>"  placeholder="https://www.youtube.com/watch?v=" type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][link_url]" id="practice_<%= area %>_attributes_<%= placeholder %>_link_url" style="width: 643px"/>
+    <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.link_url %>"  placeholder="https://www.youtube.com/watch?v=" type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][link_url]" id="practice_<%= area %>_attributes_<%= placeholder %>_link_url"/>
   </div>
 
   <div class="<%= area %>-input-container">
@@ -31,7 +31,7 @@
         message: 'Please enter a caption'
     }
     %>
-    <input <%= resource&.id ? 'required' : '' %> class="usa-input" value="<%= resource&.name %>" type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][name]" id="practice_<%= area %>_attributes_<%= placeholder %>_name" style="width: 393px"/>
+    <input <%= resource&.id ? 'required' : '' %> class="usa-input grid-col-12" value="<%= resource&.name %>" type="text" name="practice[practice_<%= area %>_attributes][<%= placeholder %>][name]" id="practice_<%= area %>_attributes_<%= placeholder %>_name"/>
   </div>
 
   <%# action buttons %>

--- a/spec/features/practice_editor/introduction/image_editor_spec.rb
+++ b/spec/features/practice_editor/introduction/image_editor_spec.rb
@@ -27,7 +27,8 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
           expect(page).to have_content('Thumbnail')
           expect(page).to have_content("Choose an image to represent this practice. Use a high-quality .jpg, .jpeg, or .png file that is at least 768px wide and 432px high and less than 32MB. If you want to upload an image that features a Veteran you must have Form 3203. Waivers must be filled out with the 'External to VA' check box selected.")
           expect(page).to have_link(href: 'https://vaww.rtp.portal.va.gov/DEAN/IE/DOE/10-3203.pdf')
-          expect(page).not_to have_css('.dm-cropper-thumbnail-modified')
+          expect(page).to have_no_css('.dm-cropper-thumbnail-modified')
+          expect(page).to have_no_css('canvas')
           expect(page).to have_no_content('Remove image')
           expect(page).to have_no_content('Edit image')
           expect(page).to have_no_content('Cancel edits')
@@ -47,6 +48,7 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
           expect(page).to have_content("Choose an image to represent this practice. Use a high-quality .jpg, .jpeg, or .png file that is at least 768px wide and 432px high and less than 32MB. If you want to upload an image that features a Veteran you must have Form 3203. Waivers must be filled out with the 'External to VA' check box selected.")
           expect(page).to have_link(href: 'https://vaww.rtp.portal.va.gov/DEAN/IE/DOE/10-3203.pdf')
           expect(page).to have_css("img[src*='acceptable_img.jpg']")
+          expect(page).to have_no_css('canvas')
           expect(page).to have_content('Remove image')
           expect(page).to have_content('Edit image')
           expect(page).to have_no_content('Drag file here or choose from folder')
@@ -73,6 +75,7 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
           expect(page).to have_css("img[src*='acceptable_img.jpg']")
           expect(page).to have_content('Remove image')
           expect(page).to have_content('Edit image')
+          expect(page).to have_no_css('canvas')
           expect(page).to have_no_content('Drag file here or choose from folder')
           expect(page).to have_no_content('Cancel edits')
           expect(page).to have_no_content('Save edits')
@@ -91,7 +94,8 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
         within('section.dm-image-editor') do
           expect(page).to have_content('Sorry, you cannot upload an image larger than 32MB.')
           expect(page).to have_content('Drag file here or choose from folder')
-          expect(page).not_to have_css("img[src*='unacceptable_img_size.png']")
+          expect(page).to have_no_css("img[src*='unacceptable_img_size.png']")
+          expect(page).to have_no_css('canvas')
           expect(page).to have_no_content('Cancel edits')
           expect(page).to have_no_content('Save edits')
           expect(page).to have_no_content('Remove image')
@@ -139,6 +143,7 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
           expect(page).to have_link(href: 'https://vaww.rtp.portal.va.gov/DEAN/IE/DOE/10-3203.pdf')
           expect(page).to have_no_css("img[src*='acceptable_img.jpg']")
           expect(page).to have_no_css('.dm-cropper-thumbnail-modified')
+          expect(page).to have_no_css('canvas')
           expect(page).to have_no_content('Remove image')
           expect(page).to have_no_content('Edit image')
           expect(page).to have_no_content('Cancel edits')
@@ -164,6 +169,7 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
           expect(page).to have_content("Choose an image to represent this practice. Use a high-quality .jpg, .jpeg, or .png file that is at least 768px wide and 432px high and less than 32MB. If you want to upload an image that features a Veteran you must have Form 3203. Waivers must be filled out with the 'External to VA' check box selected.")
           expect(page).to have_link(href: 'https://vaww.rtp.portal.va.gov/DEAN/IE/DOE/10-3203.pdf')
           expect(page).to have_no_css("img[src*='acceptable_img.jpg']")
+          expect(page).to have_no_css('canvas')
           expect(page).to have_no_content('Remove image')
           expect(page).to have_no_content('Edit image')
           expect(page).to have_no_content('Cancel edits')
@@ -186,6 +192,7 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
           expect(page).to have_content("Choose an image to represent this practice. Use a high-quality .jpg, .jpeg, or .png file that is at least 768px wide and 432px high and less than 32MB. If you want to upload an image that features a Veteran you must have Form 3203. Waivers must be filled out with the 'External to VA' check box selected.")
           expect(page).to have_link(href: 'https://vaww.rtp.portal.va.gov/DEAN/IE/DOE/10-3203.pdf')
           expect(page).to have_css("img[src*='acceptable_img.jpg']")
+          expect(page).to have_no_css('canvas')
           expect(page).to have_css('.cropper-container')
           expect(page).to have_content('Remove image')
           expect(page).to have_content('Cancel edits')
@@ -203,6 +210,7 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
           expect(find("#crop_y", :visible => false).value).to match '85'
           expect(find("#crop_w", :visible => false).value).to match '634'
           expect(find("#crop_h", :visible => false).value).to match '356'
+          expect(page).to have_css('canvas')
 
           click_remove_img
           expect(find("#crop_x", :visible => false).value).to match ''
@@ -210,8 +218,9 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
           expect(find("#crop_w", :visible => false).value).to match ''
           expect(find("#crop_h", :visible => false).value).to match ''
           expect(page).to have_content('Drag file here or choose from folder')
-          expect(page).not_to have_css("img[src*='acceptable_img.jpg']")
+          expect(page).to have_no_css("img[src*='acceptable_img.jpg']")
           expect(page).to have_no_css('.cropper-container')
+          expect(page).to have_no_css('canvas')
           expect(page).to have_no_content('Remove image')
           expect(page).to have_no_content('Cancel edits')
           expect(page).to have_no_content('Save edits')
@@ -246,6 +255,7 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
           expect(find("#crop_h", :visible => false).value).to match ''
 
           click_save_edits
+          expect(page).to have_css('canvas')
           expect(find("#crop_x", :visible => false).value).to match '79'
           expect(find("#crop_y", :visible => false).value).to match '85'
           expect(find("#crop_w", :visible => false).value).to match '634'
@@ -253,10 +263,11 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
         end
         click_edit_img
         click_save_edits
+        expect(page).to have_css('canvas')
         expect(page).to have_css(".dm-cropper-thumbnail-modified")
       end
 
-      it 'should cancel any cropping of the image' do
+      it 'should exit crop mode but retain the cropped image' do
         within('section.dm-image-editor') do
           expect(find("#crop_x", :visible => false).value).to match ''
           expect(find("#crop_y", :visible => false).value).to match ''
@@ -264,6 +275,7 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
           expect(find("#crop_h", :visible => false).value).to match ''
 
           click_save_edits
+          expect(page).to have_css('canvas')
           expect(find("#crop_x", :visible => false).value).to match '79'
           expect(find("#crop_y", :visible => false).value).to match '85'
           expect(find("#crop_w", :visible => false).value).to match '634'
@@ -271,10 +283,11 @@ describe 'Diffusion Marketplace image editor', type: :feature, js: true do
 
           click_edit_img
           click_cancel_edits
-          expect(find("#crop_x", :visible => false).value).to match ''
-          expect(find("#crop_y", :visible => false).value).to match ''
-          expect(find("#crop_w", :visible => false).value).to match ''
-          expect(find("#crop_h", :visible => false).value).to match ''
+          expect(page).to have_css('canvas')
+          expect(find("#crop_x", :visible => false).value).to match '79'
+          expect(find("#crop_y", :visible => false).value).to match '85'
+          expect(find("#crop_w", :visible => false).value).to match '634'
+          expect(find("#crop_h", :visible => false).value).to match '356'
         end
       end
     end

--- a/spec/features/practice_editor/overview/resource_file_spec.rb
+++ b/spec/features/practice_editor/overview/resource_file_spec.rb
@@ -55,7 +55,7 @@ describe 'Practice editor', type: :feature, js: true do
       end
     end
 
-    describe 'complete and add file' do
+    describe 'complete and add files' do
       before do
         no_resource_pr_test_setup
       end
@@ -100,11 +100,19 @@ describe 'Practice editor', type: :feature, js: true do
           expect(page).to have_content('Delete entry')
         end
 
+        click_file_form area
+        upload_file(area, @file_path_3)
+        fill_in('File name', with: 'second new file')
+        fill_in('File description', with: "second new practice #{area} file")
+        add_resource
+
         save_practice
         visit practice_path(@pr_no_resources)
         expect(page).to have_content("Files")
         expect(page).to have_content("new file")
         expect(page).to have_content("new practice #{area} file")
+        expect(page).to have_content("second new file")
+        expect(page).to have_content("second new practice #{area} file")
       end
 
       it 'problem section - should save file' do
@@ -243,11 +251,11 @@ describe 'Practice editor', type: :feature, js: true do
   end
 
   def name_field
-    find_all('input[type="text"][class="usa-input"]').first
+    find_all('input[type="text"]').first
   end
 
   def description_field
-    find_all('input[type="text"][class="usa-input"]').last
+    find_all('input[type="text"]').last
   end
 
   def click_file_form(area)


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
This PR fixes the following:
- styling of the "See more" buttons for the "COVID-19" and "Diffusion map" banners on the home page
- removes the `aria-describedby` attribute on file inputs on the "Overview" and "Implementation" sections of the PE
- fixes the issue of uploading/deleteing multiple files on the "Implementation" section of the PE
- fixes an issue where a resource's(video, file, link, etc.) section title was not added/removed when expected.
- Minor styling changes for copy across the practice editor(`choose from folder`,` File` attachment link, label margins).
- Fixes styling for inputs and resource containers to ensure they coincide with UX mockups.
- fixes the issue of adding/deleting multiple link on the "Implementation" section of the PE
- fixes editing of saved practice thumbnail on PE "Introduction" section

## Testing done - how did you test it/steps on how can another person can test it 
1. styling of the "See more" buttons for the "COVID-19" and "Diffusion map" banners on the home page
- Go to `/`
- Ensure the styling for the banner "See more" buttons is correct

2. removes the `aria-describedby` attribute on file inputs on the "Overview" and "Implementation" sections of the PE
- Log in as a user that can edit a practice
- Go to the PE "Overview" page
- Ensure there is no `aria-describedby` attribute on any file input component
- Go to the PE "Implementation" page
- Ensure there is no `aria-describedby` attribute on any file input component

3. fixes the issue of uploading/deleteing multiple files on the "Implementation" section of the PE
- Log in as a user that can edit a practice
- Go to the PE "Overview" page
- Ensure you can still upload multiple files for each section
- Go to the PE "Implementation" page
- Ensure you can now upload multiple files for each section
- Ensure you can now delete multiple files for each section

4.
- Log in as an admin.
- Visit the `Overview` and `Implementation` editor pages of a practice of your choosing.
- Add and remove attachments for the different types of resources(video, link, file, and image).
- Make sure that if you remove all of the attachments for a given resources that the `H5` title is removed.
- Make sure that if you add at least one attachment for a given resource that the `H5` title is added.

5.
- Log in as an admin. 
- Visit the `Introduction`, `Overview`, and `Implementation` editor pages of a practice of your choosing.
- Anywhere that has a file attachment uploader, make sure the `choose from folder` and file title text are the `primary-50v` color.

6.
- Log in as an admin.
- Visit the practice editor of any practice.
- Browse the `Overview`, `Implementation`, `Contact`, and `About` pages and make sure the input lengths and resource containers(`Overview` and `Implementation`) reflect UX mockups as best as possible.

7. fixes the issue of uploading/deleting multiple files on the "Implementation" section of the PE
- Log in as a user that can edit a practice
- Go to the PE "Overview" page
- Ensure you can still add multiple links for each section
- Go to the PE "Implementation" page
- Ensure you can now add multiple links for each section
- Ensure you can now delete multiple links for each section

8. fixes editing of saved practice thumbnail on PE "Introduction" section
- Log in as a user that can edit a practice
- Go to the PE "Introduction" page with a practice that has a saved thumbnail
- Ensure you can edit and crop the thumbnail
- Ensure you can remove and upload and edit any new thumbnails

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs