### PR TITLE
DM-2067: Added 'All adoptions' panel in Adoptions tab and wrote a uni…

### DIFF
--- a/app/admin/adoptions.rb
+++ b/app/admin/adoptions.rb
@@ -7,19 +7,21 @@ ActiveAdmin.register_page "Adoptions" do
     helper_method :adoption_rurality
     helper_method :adoption_xlsx_styles
     helper_method :get_adoption_values
-    helper_method :get_adoption_counts
+    helper_method :adoption_counts_by_practice
+    helper_method :all_adoption_counts
     before_action :set_adoption_values
 
     def set_adoption_values
       @practices = Practice.order(Arel.sql("lower(name) ASC"))
       @complete_map = {}
-      @adoption_counts = {}
+      @practice_adoption_counts = {}
       @practice_ids = {}
       @practices.each do |p|
         get_adoption_values(p, @complete_map)
-        @adoption_counts[p.name] = get_adoption_counts(p)
+        @practice_adoption_counts[p.name] = adoption_counts_by_practice(p)
         @practice_ids.merge!({p.name => p.id})
       end
+      @all_adoption_counts = all_adoption_counts
     end
   end
 
@@ -30,7 +32,7 @@ ActiveAdmin.register_page "Adoptions" do
 
         # building out xlsx file
         p.workbook.add_worksheet(:name => "Practice Adoptions - #{Date.today}") do |sheet|
-          sheet.add_row ["Adoptions by Practice - #{Date.today}"], style: @xlsx_main_header
+          sheet.add_row ['Practice Adoptions'], style: @xlsx_main_header
           sheet.add_row [''], style: @xlsx_divider
           sheet.add_row ['Please Note'], style: @xlsx_legend_no_bottom_border
           sheet.add_row ['Adoption date is based on the adoption status.'], style: @xlsx_legend_no_y_border
@@ -40,6 +42,14 @@ ActiveAdmin.register_page "Adoptions" do
           sheet.merge_cells 'A1:C1'
           sheet.add_row [''], style: @xlsx_divider
 
+          sheet.add_row ['All adoptions'], style: @xlsx_sub_header_2
+          sheet.add_row ["#{@date_headers[:current]}", @all_adoption_counts[:adoptions_this_month]], style: @xlsx_entry
+          sheet.add_row ["#{@date_headers[:one_month_ago]}", @all_adoption_counts[:adoptions_one_month_ago]], style: @xlsx_entry
+          sheet.add_row ["#{@date_headers[:two_month_ago]}", @all_adoption_counts[:adoptions_two_months_ago]], style: @xlsx_entry
+          sheet.add_row ["#{@date_headers[:total]}", @all_adoption_counts[:total_adoptions]], style: @xlsx_entry
+
+          sheet.add_row [''], style: @xlsx_divider
+
           @complete_map.each do |name, value|
             if value.present?
               practice_id = @practice_ids[name]
@@ -47,7 +57,7 @@ ActiveAdmin.register_page "Adoptions" do
               sheet.add_row ["Practice Id", practice_id], style: @xlsx_entry
               # adoption counts
               sheet.add_row ['Adoption Counts'], style: @xlsx_sub_header
-              @adoption_counts.each do |key, counts|
+              @practice_adoption_counts.each do |key, counts|
                 if key == name
                   sheet.add_row ["#{@date_headers[:current]}", counts[:adopted_this_month]], style: @xlsx_entry
                   sheet.add_row ["#{@date_headers[:one_month_ago]}", counts[:adopted_one_month_ago]], style: @xlsx_entry
@@ -94,30 +104,40 @@ ActiveAdmin.register_page "Adoptions" do
   end
 
   content do
-    if DiffusionHistory.any?
-      h1 'Adoptions by practice'
-      div(class: 'form-and-legend-container') do
-        # export .xlsx button
-        form action: admin_adoptions_export_all_adoptions_path, method: :get, style: 'text-align: left' do |f|
-          f.input :submit, type: :submit, value: 'Download All', style: 'margin-bottom: 1rem'
-        end
+    div(class: 'form-and-legend-container') do
+      # export .xlsx button
+      form action: admin_adoptions_export_all_adoptions_path, method: :get, style: 'text-align: left' do |f|
+        f.input :submit, type: :submit, value: 'Download All', style: 'margin-bottom: 1rem'
+      end
 
-        div(class: 'adoptions-legend') do
-          h3 do
-            'Please Note'
+      div(class: 'adoptions-legend') do
+        h3 do
+          'Please Note'
+        end
+        h4 do
+          span 'Adoption date is based on the adoption status.'
+        end
+        ul do
+          li do
+            span 'Completed/Unsuccessful: '
+            span 'End Date'
           end
-          h4 do
-            span 'Adoption date is based on the adoption status.'
+          li do
+            span 'In Progress: '
+            span 'Start Date'
           end
-          ul do
-            li do
-              span 'Completed/Unsuccessful: '
-              span 'End Date'
-            end
-            li do
-              span 'In Progress: '
-              span 'Start Date'
-            end
+        end
+      end
+    end
+
+    if DiffusionHistory.any?
+      panel 'All adoptions' do
+        columns class: 'all-adoptions-columns' do
+          table_for all_adoption_counts do
+            column("#{date_headers[:current]}", class: "all-adoptions-current-month") {|ac| ac[:adoptions_this_month]}
+            column("#{date_headers[:one_month_ago]}", class: "all-adoptions-last-month") {|ac| ac[:adoptions_one_month_ago]}
+            column("#{date_headers[:two_month_ago]}", class: "all-adoptions-two-months-ago") {|ac| ac[:adoptions_two_months_ago]}
+            column("#{date_headers[:total]}", class: "all-adoptions-total") {|ac| ac[:total_adoptions]}
           end
         end
       end
@@ -130,7 +150,7 @@ ActiveAdmin.register_page "Adoptions" do
               h3 do
                 "Adoption Counts"
               end
-              adoption_counts.each do |key, counts|
+              practice_adoption_counts.each do |key, counts|
                 if key == name
                   table_for counts do
                     column("#{date_headers[:current]}") {|c| c[:adopted_this_month]}

--- a/app/admin/practices.rb
+++ b/app/admin/practices.rb
@@ -156,7 +156,7 @@ ActiveAdmin.register Practice do
     helper_method :adoption_date
     helper_method :adoption_rurality
     helper_method :get_adoption_values
-    helper_method :get_adoption_counts
+    helper_method :adoption_counts_by_practice
     helper_method :adoption_xlsx_styles
     before_action :set_categories_view, only: :edit
     before_action :set_practice_adoption_values, only: [:show, :export_practice_adoptions]
@@ -180,7 +180,7 @@ ActiveAdmin.register Practice do
       @complete_map = {}
       @adoption_counts = {}
       get_adoption_values(resource, @complete_map)
-      @adoption_counts = get_adoption_counts(resource)
+      @adoption_counts = adoption_counts_by_practice(resource)
     end
 
     def set_practice_user(practice)

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -120,7 +120,7 @@ fieldset.page_components.inputs.has_many_fields {
 
 .form-and-legend-container {
   position: relative;
-  margin-top: 1.8rem;
+  margin-top: 5.15rem;
 }
 
 .adoptions-legend {

--- a/app/helpers/active_admin_helpers.rb
+++ b/app/helpers/active_admin_helpers.rb
@@ -52,12 +52,22 @@ module ActiveAdminHelpers
     }
   end
 
-  def get_adoption_counts(p)
+  def all_adoption_counts
+    set_date_values
+    {
+      adoptions_this_month: DiffusionHistory.where(created_at: @beginning_of_current_month..@end_of_current_month).count,
+      adoptions_one_month_ago: DiffusionHistory.where(created_at: @beginning_of_last_month..@end_of_last_month).count,
+      adoptions_two_months_ago: DiffusionHistory.where(created_at: @beginning_of_two_months_ago..@end_of_two_months_ago).count,
+      total_adoptions: DiffusionHistory.count
+    }
+  end
+
+  def adoption_counts_by_practice(p)
     set_date_values
     {
         adopted_this_month: p.diffusion_histories.where(created_at: @beginning_of_current_month..@end_of_current_month).count,
         adopted_one_month_ago: p.diffusion_histories.where(created_at: @beginning_of_last_month..@end_of_last_month).count,
-        adopted_two_months_ago: p.diffusion_histories.where(created_at: @beginning_of_last_month..@end_of_last_month).count,
+        adopted_two_months_ago: p.diffusion_histories.where(created_at: @beginning_of_two_months_ago..@end_of_two_months_ago).count,
         total_adopted: p.diffusion_histories.count
     }
   end

--- a/spec/features/admin_adoptions_spec.rb
+++ b/spec/features/admin_adoptions_spec.rb
@@ -9,8 +9,10 @@ describe 'Admin Adoptions Tab', type: :feature do
     login_as(@admin, scope: :user, run_callbacks: false)
     @diffusion_history = DiffusionHistory.create!(practice_id: @practice.id, facility_id: '600GC')
     @diffusion_history_2 = DiffusionHistory.create!(practice_id: @practice.id, facility_id: '516')
+    @diffusion_history_3 = DiffusionHistory.create!(practice_id: @practice.id, facility_id: '649GD', created_at: Date.today - 1.months)
     @diffusion_history_status = DiffusionHistoryStatus.create!(diffusion_history_id: @diffusion_history.id, status: 'In progress')
     @diffusion_history_status_2 = DiffusionHistoryStatus.create!(diffusion_history_id: @diffusion_history_2.id, status: 'Unsuccessful')
+    @diffusion_history_status_3 = DiffusionHistoryStatus.create!(diffusion_history_id: @diffusion_history_3.id, status: 'Completed')
   end
 
   it 'should show all adoptions and adoption counts for practices that have at least one adoption' do
@@ -18,7 +20,7 @@ describe 'Admin Adoptions Tab', type: :feature do
     click_link 'Adoptions'
 
     expect(page).to have_selector("input[value='Download All']")
-    expect(page).to have_selector('.panel', count: 1)
+    expect(page).to have_selector('.panel', count: 2)
     expect(page).to have_content('CURRENT MONTH')
     expect(page).to have_content('LAST MONTH')
     expect(page).to have_content('2 MONTHS AGO')
@@ -26,6 +28,24 @@ describe 'Admin Adoptions Tab', type: :feature do
     expect(page).to have_content('The Best Practice Ever!')
     expect(page).to have_content('Cabrillo VA Clinic')
     expect(page).to have_content('C.W. Bill Young Department of Veterans Affairs Medical Center (Bay Pines)')
+  end
+
+  it 'should show the total adoptions for all practices and adoptions made within a 3-month interval(current month, one month ago, two months ago)' do
+    visit '/admin'
+    click_link 'Adoptions'
+
+    expect(page).to have_content('All adoptions')
+    within(:css, '.all-adoptions-columns') do
+      current_month_el = all(".all-adoptions-current-month").last
+      last_month_el = all(".all-adoptions-last-month").last
+      two_months_ago_el = all(".all-adoptions-two-months-ago").last
+      total_el = all(".all-adoptions-total").last
+
+      expect(current_month_el.text).to eq('2')
+      expect(last_month_el.text).to eq('1')
+      expect(two_months_ago_el.text).to eq('0')
+      expect(total_el.text).to eq('3')
+    end
   end
 
   it 'should allow an admin to download adoption data as a .xlsx file' do


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2067

## Description - what does this code do?
Add a panel to the `Adoptions` tab of active admin that displays all adoptions for the `current month`, `last month`, `two months ago` and `total`. It also adds this data to the downloadable spreadsheet.

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin.
2. Visit `/admin/adoptions`.
3. Make sure you see an `All adoptions` panel above the first practice's panel that displays the counts for each grouping listed in the description above.
4. To ensure accuracy, open up a new window and browse to `/practices/*practice slug*/edit/adoptions` of a practice of your choosing.
5. Add or remove adoptions as you please.
6. Go back to the admin panel's `Adoptions` tab and refresh the page to make sure the data has been updated.
7. Click on `Download all` and make sure the `All adoptions` header is there along with the data from above.

## Screenshots, Gifs, Videos from application (if applicable)
![Screen Shot 2020-10-14 at 1 57 37 PM](https://user-images.githubusercontent.com/34111449/96027071-59512100-0e25-11eb-8927-3627277d61ed.png)
![Screen Shot 2020-10-14 at 1 58 19 PM](https://user-images.githubusercontent.com/34111449/96027098-63731f80-0e25-11eb-8390-10195a4eb145.png)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [In Active Admin]
- [Total adoptions aggregate at top of Adoptions page, not by practice]
- [Number ADDED by month]
- [Running total each month in column, then lifetime total (Three months)]
- [Look at Commits, Leaderboard as examples]
- [Blake wants to see trends, make sure people are adding to map]
- [New section on “Adoptions” Page in Active Admin]
- [Add to spreadsheet too]

## Definition of done
- [X] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs