### PR TITLE
DM-2147: Zoom out practice diffusion map

### DIFF
--- a/app/assets/javascripts/diffusion_history/practice_map.es6
+++ b/app/assets/javascripts/diffusion_history/practice_map.es6
@@ -71,6 +71,8 @@ function initialize() {
 
     handler.buildMap({
             provider: {
+                zoom: 2,
+                center: {lat: 44.967243, lng:  -103.771556},
                 zoomControlOptions: {
                     position: google.maps.ControlPosition.TOP_RIGHT
                 },
@@ -91,7 +93,6 @@ function initialize() {
             buildMapMarkers(mapData);
 
             handler.bounds.extendWith(markers);
-            handler.fitMapToBounds();
         });
 
     google.maps.event.addListener(handler.getMap(), 'click', function () {


### PR DESCRIPTION
### JIRA issue link
[DM-2147](https://agile6.atlassian.net/browse/DM-2147)

## Description - what does this code do?
This PR zooms out the practice diffusion map so that when a practice has one adoption the practice map is not zoomed in to the street level. This PR also centers the map so that Alaska, Hawaii, and the continental US appear on practice page load.

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as a user that can view a practice.
2. Go to a practice with one adoption.
3. Ensure you can see Alaska, Hawaii, and the continental US on practice page load as well as the marker.
4. Go to a practice with multiple adoptions.
5. Ensure you can see Alaska, Hawaii, and the continental US on practice page load as well as the markers.

## Screenshots, Gifs, Videos from application (if applicable)
<img width="901" alt="Screen Shot 2020-10-20 at 11 00 54 AM" src="https://user-images.githubusercontent.com/20211771/96615846-71162280-12c7-11eb-91cc-5f0dafcea023.png">
<img width="861" alt="Screen Shot 2020-10-20 at 11 16 50 AM" src="https://user-images.githubusercontent.com/20211771/96615856-74111300-12c7-11eb-9033-f3ed3efbf7c9.png">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs