### PR TITLE
Dm 2166

### DIFF
--- a/app/views/practices/form/about.html.erb
+++ b/app/views/practices/form/about.html.erb
@@ -63,10 +63,13 @@
                       <li class="practice-editor-about-li fields" <%= "id=practice_va_employees_attributes_#{vae.index}_li" if vae_id %> role="option" data-id="<%= vae_id %>">
                         <div class="grid-row">
                           <div class="grid-col-12">
-                            <%= vae.label :name, 'Name (Type the name of the team member.)', class: 'usa-label x0-top' %>
+                            <div title="Type the name of the team member.">
+                              <%= vae.label :name, 'Name', class: 'usa-label x0-top', alt: 'hello' %>
+                            </div>
                             <%= vae.text_field :name, class: 'usa-input practice-input va-employee-name-input' %>
-
-                            <%= vae.label :role, 'Role (Type the job title of the team member.)', class: 'usa-label' %>
+                            <div title="Type the job title of the team member.">
+                              <%= vae.label :role, 'Role', class: 'usa-label' %>
+                            </div>
                             <%= vae.text_field :role, class: 'usa-input practice-input va-employee-role' %>
                           </div>
                           <div class="trash-container grid-col-12">

--- a/app/views/practices/form/about.html.erb
+++ b/app/views/practices/form/about.html.erb
@@ -35,7 +35,7 @@
               <div class="practice-editor-rect-svg border-top-05 border-primary-dark"></div>
               <div class="margin-top-3 margin-bottom-2">
                 <p class="text-bold margin-bottom-2 line-height-18px">Team members</p>
-                <p class="line-height-26">Add the names of people who helped start the practice.</p>
+                <p class="line-height-26">Add the names of people who are responsible for this practice.</p>
               </div>
               <div class="grid-col-7">
                 <div id="about_container" class="position-relative">
@@ -63,10 +63,10 @@
                       <li class="practice-editor-about-li fields" <%= "id=practice_va_employees_attributes_#{vae.index}_li" if vae_id %> role="option" data-id="<%= vae_id %>">
                         <div class="grid-row">
                           <div class="grid-col-12">
-                            <%= vae.label :name, 'Name', class: 'usa-label x0-top' %>
+                            <%= vae.label :name, 'Name (Type the name of the team member.)', class: 'usa-label x0-top' %>
                             <%= vae.text_field :name, class: 'usa-input practice-input va-employee-name-input' %>
 
-                            <%= vae.label :role, 'Role', class: 'usa-label' %>
+                            <%= vae.label :role, 'Role (Type the job title of the team member.)', class: 'usa-label' %>
                             <%= vae.text_field :role, class: 'usa-input practice-input va-employee-role' %>
                           </div>
                           <div class="trash-container grid-col-12">

--- a/app/views/practices/form/about.html.erb
+++ b/app/views/practices/form/about.html.erb
@@ -63,13 +63,12 @@
                       <li class="practice-editor-about-li fields" <%= "id=practice_va_employees_attributes_#{vae.index}_li" if vae_id %> role="option" data-id="<%= vae_id %>">
                         <div class="grid-row">
                           <div class="grid-col-12">
-                            <div title="Type the name of the team member.">
+
                               <%= vae.label :name, 'Name', class: 'usa-label x0-top', alt: 'hello' %>
-                            </div>
+                            <div>Type the name of the team member.</div>
                             <%= vae.text_field :name, class: 'usa-input practice-input va-employee-name-input' %>
-                            <div title="Type the job title of the team member.">
-                              <%= vae.label :role, 'Role', class: 'usa-label' %>
-                            </div>
+                            <%= vae.label :role, 'Role', class: 'usa-label' %>
+                            <div>Type the job title of the team member. </div>
                             <%= vae.text_field :role, class: 'usa-input practice-input va-employee-role' %>
                           </div>
                           <div class="trash-container grid-col-12">

--- a/app/views/practices/form/contact.html.erb
+++ b/app/views/practices/form/contact.html.erb
@@ -27,7 +27,8 @@
             <div class="margin-bottom-5">
               <div class="practice-editor-rect-svg border-top-05 border-primary-dark"></div>
               <h4 class="line-height-18px margin-top-3 font-sans-sm text-bold margin-bottom-2">Email <span class="text-gray-50">(required field)</span></h4>
-              <p class="line-height-26 margin-bottom-2">Type the email address dedicated to responding to messages for this practice.</p>
+              <p class="line-height-26 margin-bottom-2">Type at least one email address dedicated to responding to messages for this practice.
+              </p>
 
               <div class="grid-col-7 main-practice-email-container">
                 <%= f.label :support_network_email, 'Main email address', class: 'usa-label line-height-26 x0-top main-practice-email-label' %>

--- a/app/views/practices/form/introduction.html.erb
+++ b/app/views/practices/form/introduction.html.erb
@@ -105,7 +105,7 @@
                 Summary <span class="text-gray-50">(required field)</span>
               <% end %>
               <span class="line-height-26">
-                Type a short 1-3 sentence summary of your practice’s mission to engage the audience and provide initial context. 
+                Type a short 1-3 sentence summary of your practice’s mission to engage the audience and provide initial context.
               </span>
               <%= f.text_area :summary, class: 'usa-textarea display-block practice-editor-summary-textarea', required: @practice.published %>
             </div>

--- a/app/views/practices/form/introduction.html.erb
+++ b/app/views/practices/form/introduction.html.erb
@@ -105,8 +105,7 @@
                 Summary <span class="text-gray-50">(required field)</span>
               <% end %>
               <span class="line-height-26">
-                Type a short summary of your practice’s mission to engage the audience
-                and provide initial context.
+                Type a short 1-3 sentence summary of your practice’s mission to engage the audience and provide initial context. 
               </span>
               <%= f.text_area :summary, class: 'usa-textarea display-block practice-editor-summary-textarea', required: @practice.published %>
             </div>

--- a/app/views/practices/show/authenticated/_show_authenticated.html.erb
+++ b/app/views/practices/show/authenticated/_show_authenticated.html.erb
@@ -194,37 +194,3 @@
     </div>
   </div>
 </section>
-
-<!-- "Documentation" section -->
-<% if @practice.additional_documents.any? || @practice.publications.any? %>
-  <section class="margin-bottom-4">
-    <div class="grid-container">
-      <div class="grid-row grid-gap">
-        <div class="desktop:grid-col-3 grid-col-auto z-bottom">&nbsp;</div>
-        <div class="desktop:grid-col-9 grid-col-12 p0">
-          <div class="grid-row flex-align-center margin-bottom-30px">
-            <h2 class="font-sans-xl text-bold margin-y-0 flex-auto margin-right-205">Documentation</h2>
-            <hr class="flex-fill height-2px border border-base-lightest bg-base-lightest dm-section-line">
-          </div>
-          <% if @practice.additional_documents.any? %>
-            <h3 class="font-sans-lg margin-top-0 margin-bottom-1">Downloads</h3>
-            <div>
-              <%= render partial: 'additional_documents' %>
-            </div>
-          <% else %>
-            <div class="hidden"></div>
-          <% end %>
-
-          <% if @practice.publications.any? %>
-            <h3 class="font-sans-lg margin-top-0 margin-bottom-1">Links</h3>
-            <div>
-              <%= render partial: 'publications' %>
-            </div>
-          <% else %>
-            <div class="hidden"></div>
-          <% end %>
-        </div>
-      </div>
-    </div>
-  </section>
-<% end %>

--- a/app/views/practices/show/implementation/_resource_file_attachment.html.erb
+++ b/app/views/practices/show/implementation/_resource_file_attachment.html.erb
@@ -2,7 +2,9 @@
 <ul class="usa-list--unstyled margin-bottom-5">
   <% file_attachments.each do |fa| %>
     <div class="margin-bottom-1">
-      <% if fa.name.present? %>
+      <% if fa.attachment_file_name.present? %>
+          <% fa.name = fa.attachment_file_name unless fa.name.present? %>
+          <% fa.description = fa.attachment_file_name unless fa.description.present? %>
         <div class="margin-top-1 width-100 line-height-26">
           <li class="small-disc"><%= fa.description %> <%= link_to(fa.name || fa.attachment&.original_filename, fa.attachment_s3_presigned_url, target: '_blank', class: 'dm-external-link') %>
         </div>

--- a/app/views/practices/show/implementation/_resource_file_attachment.html.erb
+++ b/app/views/practices/show/implementation/_resource_file_attachment.html.erb
@@ -2,9 +2,7 @@
 <ul class="usa-list--unstyled margin-bottom-5">
   <% file_attachments.each do |fa| %>
     <div class="margin-bottom-1">
-      <% if fa.attachment_file_name.present? %>
-          <% fa.name = fa.attachment_file_name unless fa.name.present? %>
-          <% fa.description = fa.attachment_file_name unless fa.description.present? %>
+      <% if fa.attachment.present? %>
         <div class="margin-top-1 width-100 line-height-26">
           <li class="small-disc"><%= fa.description %> <%= link_to(fa.name || fa.attachment&.original_filename, fa.attachment_s3_presigned_url, target: '_blank', class: 'dm-external-link') %>
         </div>

--- a/app/views/practices/show/implementation/_resource_link_attachment.html.erb
+++ b/app/views/practices/show/implementation/_resource_link_attachment.html.erb
@@ -7,9 +7,8 @@
           <% la.link_url = "http://" + la.link_url %>
         <% end %>
         <% la.name = la.link_url unless la.name.present? %>
-        <% la.description = la.link_url unless la.description.present? %>
         <div class="margin-top-1 width-100 line-height-26">
-          <li class="small-disc"><%= la.description %> <a class="<%= la.link_url.downcase().include?('marketplace.gov') ? 'dm-internal-link' : 'dm-external-link usa-link--external' %>" href="<%= la.link_url %>" target="_blank"><%= la.name %></a></li>
+          <li class="small-disc"><%= la.description %> <a class="<%= la.link_url.downcase().include?('marketplace.gov') ? 'dm-internal-link' : 'dm-external-link usa-link--external' %>" href="<%= la.link_url %>" target="_blank"><%= la.name || la.link_url %></a></li>
         </div>
       <% end %>
     </div>

--- a/app/views/practices/show/implementation/_resource_link_attachment.html.erb
+++ b/app/views/practices/show/implementation/_resource_link_attachment.html.erb
@@ -2,10 +2,12 @@
 <ul class="usa-list--unstyled margin-bottom-5">
   <% link_attachments.each do |la| %>
     <div class="margin-bottom-1">
-      <% if la.name.present? %>
+      <% if la.link_url.present? %>
         <% unless la.link_url.start_with?("http") %>
           <% la.link_url = "http://" + la.link_url %>
         <% end %>
+        <% la.name = la.link_url unless la.name.present? %>
+        <% la.description = la.link_url unless la.description.present? %>
         <div class="margin-top-1 width-100 line-height-26">
           <li class="small-disc"><%= la.description %> <a class="<%= la.link_url.downcase().include?('marketplace.gov') ? 'dm-internal-link' : 'dm-external-link usa-link--external' %>" href="<%= la.link_url %>" target="_blank"><%= la.name %></a></li>
         </div>

--- a/app/views/practices/show/implementation/_resource_table.html.erb
+++ b/app/views/practices/show/implementation/_resource_table.html.erb
@@ -1,5 +1,3 @@
-<div class="practice-editor-rect-svg border-top-05 border-primary-dark"></div>
-<h3 class="margin-top-2 margin-bottom-2 line-height-25px font-sans-lg"><%= table_name %></h3>
 <table class="usa-table usa-table--borderless dm-resource-table margin-bottom-5">
   <tbody>
     <% people = practice.practice_resources.where(resource_type: "#{resource_type}", media_type: 'resource', resource_type_label: 'people') %>

--- a/app/views/practices/show/implementation/_show_resources.html.erb
+++ b/app/views/practices/show/implementation/_show_resources.html.erb
@@ -1,80 +1,88 @@
-<% core_resources = @practice.practice_resources.where(resource_type: 'core') %>
-<% if core_resources.any? %>
-  <%= render partial: 'practices/show/implementation/resource_table', locals: {
-      table_name: 'Core resources',
-      resource_type: 'core',
-      practice: @practice
-    }
-  %>
-<% end %>
-<!---core files --->
+<% core_resources = @practice.practice_resources.where(resource_type: 'core', media_type: 'resource') %>
 <% core_file_attachments = @practice.practice_resources.where(resource_type: 'core', media_type: 'file') %>
-<% if core_file_attachments.any? %>
-  <%= render partial: 'practices/show/implementation/resource_file_attachment', locals: {
-      file_attachments: core_file_attachments
-    }
-  %>
-<% end %>
-<!--- core links --->
 <% core_link_attachments = @practice.practice_resources.where(resource_type: 'core', media_type: 'link') %>
-<% if core_link_attachments.any? %>
-  <%= render partial: 'practices/show/implementation/resource_link_attachment', locals: {
-      link_attachments: core_link_attachments
+<% if core_resources.any? || core_file_attachments.any? || core_link_attachments.any? %>
+  <div class="practice-editor-rect-svg border-top-05 border-primary-dark"></div>
+  <h3 class="margin-top-2 margin-bottom-2 line-height-25px font-sans-lg">Core Resources</h3>
+  <% if core_resources.any? %>
+    <%= render partial: 'practices/show/implementation/resource_table', locals: {
+        resource_type: 'core',
+        practice: @practice
     }
-  %>
+    %>
+  <% end %>
+  <!---core files --->
+  <% if core_file_attachments.any? %>
+    <%= render partial: 'practices/show/implementation/resource_file_attachment', locals: {
+        file_attachments: core_file_attachments
+    }
+    %>
+  <% end %>
+  <!--- core links --->
+  <% if core_link_attachments.any? %>
+    <%= render partial: 'practices/show/implementation/resource_link_attachment', locals: {
+        link_attachments: core_link_attachments
+    }
+    %>
+  <% end %>
 <% end %>
 
-
-<!--- Optional Resources --->
-<% optional_resources = @practice.practice_resources.where(resource_type: 'optional') %>
-<% if optional_resources.any? %>
-  <%= render partial: 'practices/show/implementation/resource_table', locals:{
-      table_name: 'Optional resources',
-      resource_type: 'optional',
-      practice: @practice
-    }
-  %>
-<% end %>
-<!---optional files --->
+<!--- Optional --->
+<% optional_resources = @practice.practice_resources.where(resource_type: 'optional', media_type: 'resource') %>
 <% optional_file_attachments = @practice.practice_resources.where(resource_type: 'optional', media_type: 'file') %>
-<% if optional_file_attachments.any? %>
-  <%= render partial: 'practices/show/implementation/resource_file_attachment', locals: {
-      file_attachments: optional_file_attachments
-    }
-  %>
-<% end %>
-<!--- optional links --->
 <% optional_link_attachments = @practice.practice_resources.where(resource_type: 'optional', media_type: 'link') %>
-<% if optional_link_attachments.any? %>
-  <%= render partial: 'practices/show/implementation/resource_link_attachment', locals: {
-      link_attachments: optional_link_attachments
+<% if optional_resources.any? || optional_file_attachments.any? || optional_link_attachments.any? %>
+  <div class="practice-editor-rect-svg border-top-05 border-primary-dark"></div>
+  <h3 class="margin-top-2 margin-bottom-2 line-height-25px font-sans-lg">Optional Resources</h3>
+  <% if optional_resources.any? %>
+    <%= render partial: 'practices/show/implementation/resource_table', locals: {
+        resource_type: 'optional',
+        practice: @practice
     }
-  %>
+    %>
+  <% end %>
+  <!---optional files --->
+  <% if optional_file_attachments.any? %>
+    <%= render partial: 'practices/show/implementation/resource_file_attachment', locals: {
+        file_attachments: optional_file_attachments
+    }
+    %>
+  <% end %>
+  <!--- optional links --->
+  <% if optional_link_attachments.any? %>
+    <%= render partial: 'practices/show/implementation/resource_link_attachment', locals: {
+        link_attachments: optional_link_attachments
+    }
+    %>
+  <% end %>
 <% end %>
 
-<!--- Support Resources --->
-<% support_resources = @practice.practice_resources.where(resource_type: 'support') %>
-<% if support_resources.any? %>
-  <%= render partial: 'practices/show/implementation/resource_table', locals: {
-      table_name: 'Support resources',
-      resource_type: 'support',
-      practice: @practice
-    }
-  %>
-<% end %>
-<!---support files --->
+<!-- Support --->
+<% support_resources = @practice.practice_resources.where(resource_type: 'support', media_type: 'resource') %>
 <% support_file_attachments = @practice.practice_resources.where(resource_type: 'support', media_type: 'file') %>
-<% if support_file_attachments.any? %>
-  <%= render partial: 'practices/show/implementation/resource_file_attachment', locals: {
-      file_attachments: support_file_attachments
-    }
-  %>
-<% end %>
-<!--- support links --->
 <% support_link_attachments = @practice.practice_resources.where(resource_type: 'support', media_type: 'link') %>
-<% if support_link_attachments.any? %>
-  <%= render partial: 'practices/show/implementation/resource_link_attachment', locals: {
-      link_attachments: support_link_attachments
+<% if support_resources.any? || support_file_attachments.any? || support_link_attachments.any? %>
+  <div class="practice-editor-rect-svg border-top-05 border-primary-dark"></div>
+  <h3 class="margin-top-2 margin-bottom-2 line-height-25px font-sans-lg">Support Resources</h3>
+  <% if support_resources.any? %>
+    <%= render partial: 'practices/show/implementation/resource_table', locals: {
+        resource_type: 'support',
+        practice: @practice
     }
-  %>
+    %>
+  <% end %>
+  <!---support files --->
+  <% if support_file_attachments.any? %>
+    <%= render partial: 'practices/show/implementation/resource_file_attachment', locals: {
+        file_attachments: support_file_attachments
+    }
+    %>
+  <% end %>
+  <!--- support links --->
+  <% if support_link_attachments.any? %>
+    <%= render partial: 'practices/show/implementation/resource_link_attachment', locals: {
+        link_attachments: support_link_attachments
+    }
+    %>
+  <% end %>
 <% end %>

--- a/lib/tasks/documentation.rake
+++ b/lib/tasks/documentation.rake
@@ -1,0 +1,48 @@
+namespace :documentation do
+  desc "transfers all publications (links) and additional documents (files) to core practice resources"
+  task port_additional_documents_to_practice_resources: :environment do
+    Practice.all.each do |p|
+      if p.additional_documents.any?
+        p.additional_documents.each do |ad|
+          # A not-so-fool-proof way to check if this practice resource was already created
+          # just in case this was ran twice in a row on accident
+          duplicate_document = p.practice_resources.where(attachment_file_name: ad.attachment_file_name)
+          if duplicate_document.empty?
+            practice_resource = p.practice_resources.new(
+                resource_type: 'core',
+                media_type: 'file',
+                name: ad.title,
+                description: ad.description
+            )
+            practice_resource.attachment = ad.attachment
+            save_resource(p, practice_resource)
+          else
+            puts "A practice resource already exists with the attachment_file_name #{duplicate_document.first.attachment_file_name}"
+          end
+        end
+      end
+    end
+    puts "All additional documents have been successfully transferred to core practice resource files!"
+  end
+  task port_publications_to_practice_resources: :environment do
+    Publication.all.each do |pub|
+      PracticeResource.find_or_create_by!({
+                                              practice_id: pub.practice_id,
+                                              link_url: pub.link,
+                                              description: pub.description,
+                                              name: pub.title,
+                                              resource_type: 'core',
+                                              media_type: 'link'
+                                          })
+    end
+    puts "All practice publications have been successfully transferred to core practice resource links!"
+  end
+  def save_resource(p, resource)
+    if resource.save
+      puts "Created PracticeResource for: #{p.id} - #{p.name}"
+    else
+      puts "Could not create PracticeResource for: #{p.id} - #{p.name}"
+      puts "#{resource.errors}"
+    end
+  end
+end

--- a/spec/features/practice_editor/introduction/introduction_spec.rb
+++ b/spec/features/practice_editor/introduction/introduction_spec.rb
@@ -39,7 +39,7 @@ describe 'Practice editor - introduction', type: :feature, js: true do
       expect(page).to have_content('Type the official name of your practice.')
       expect(page).to have_content('Acronym')
       expect(page).to have_content('Summary (required field)')
-      expect(page).to have_content('Type a short summary of your practice’s mission to engage the audience and provide initial context.')
+      expect(page).to have_content('Type a short 1-3 sentence summary of your practice’s mission to engage the audience and provide initial context.')
       expect(page).to have_content('Date created (required field)')
       expect(page).to have_content('Select the month and year this practice was created.')
       expect(page).to have_content('Practice origin (required field)')


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2166

## Description - what does this code do?
1.  Script to move users uploaded documents to PE Implementation to Core Resources section.  The script ports Links from the "Publication" table and Files from the "Additional Documents" section to the practice_resources table.  Links and files display in the "Core resources attachments" section.
2.  Removes the Documentation section from the practice show view.
![image](https://user-images.githubusercontent.com/60527788/97923107-55bd0580-1d12-11eb-9bc5-29b5d8960fa7.png)

3.  Copy tweaks for PE About section:  (Also tool tips added for "Name" and "Role" label fields when you hover over them.
![image](https://user-images.githubusercontent.com/60527788/97923371-b6e4d900-1d12-11eb-9c27-654d89b39a6d.png)
4.  Copy tweaks for PE Contact Section: 
![image](https://user-images.githubusercontent.com/60527788/97923441-d7ad2e80-1d12-11eb-94a9-91d96f265235.png)
5.  Copy Tweak for PE Introduction -> Summary section.
![image](https://user-images.githubusercontent.com/60527788/97923563-0aefbd80-1d13-11eb-9a2a-b54eafd33727.png)


## Testing done - how did you test it/steps on how can another person can test it 
Script to port Links and Files to resources core section.  
1.  Note the records you have in your local DB publications and additional_documents tables.
2.  Run the following two tasks from the lib/tasks/documentation.rake file:
     a.  port_additional_documents_to_practice_resources
     b.  port_publications_to_practice_resources
3.  Records in the two tables above should now have records in the practice_resources table.. with resource_type = 0 (Core) and media_type = 1 for files and 2 for links.
4.  Login to DM and verify that the Links and Files ported from the 'publication' and 'additional_documents' tables show up in the "Core Resource Attachments" section.
==============================================================
Remove Documentation Section.
1.  Login and visit a practice show page.  
 => there should be no documentation section at the bottom of the page.
===============================================================
Copy Tweaks
Login and verify the copy updates for PE about, contact and Introduction sections - see images above.


## Link to mock-ups/mock ups (image file if you have it) (if applicable)
Copy updates taken from this doc: https://docs.google.com/document/d/12FMO7do1BVXs3nfpsY_B2ynnp53R2BBBn1DPgHPQwl4/edit#

## Acceptance criteria
Script to port documents to resources:
1.  Write script to port "Downloads" and "Links" into the Core Resources section
2.  Publications->Links
3.  Additional Documents->Files

For Copy tweaks you can reference the Print bug Spread sheet: https://drive.google.com/file/d/163NX9FbvAA4Bzsb8ZfrDP5Eg8R41GAX1/view
and the Practice editor fields sprint 35 - doc: https://docs.google.com/document/d/12FMO7do1BVXs3nfpsY_B2ynnp53R2BBBn1DPgHPQwl4/edit#


## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs