### PR TITLE
DM-2201: Fix deleting dept assoc w/ practice in admin panel

### DIFF
--- a/app/admin/categories.rb
+++ b/app/admin/categories.rb
@@ -52,7 +52,7 @@ ActiveAdmin.register Category do
       deleted = remove_category
       respond_to do |format|
         if deleted
-          format.html { redirect_to admin_categories_path(notice: 'Category was successfully deleted.') }
+          format.html { redirect_to admin_categories_path, notice: 'Category was successfully deleted.' }
         else
           format.html { redirect_to edit_admin_category_path(id: params[:id]), :flash => { :error => 'There was an error deleting your category.' }}
         end

--- a/app/admin/departments.rb
+++ b/app/admin/departments.rb
@@ -1,16 +1,43 @@
 ActiveAdmin.register Department do
+  batch_action :destroy, false
+
   permit_params :position, :name, :short_name, :description, :id
 
   filter :name
   filter :description
 
   index do
-    selectable_column
     id_column
     column :position
     column :short_name
     column :name
     column :description
     actions
+  end
+
+  controller do
+    def destroy
+      deleted = remove_department
+      respond_to do |format|
+        if deleted
+          format.html { redirect_to admin_departments_path, notice: 'Department was successfully deleted.' }
+        else
+          format.html { redirect_to edit_admin_department_path(id: params[:id]), :flash => { :error => 'There was an error deleting your department.' }}
+        end
+      end
+    end
+
+    private
+
+    def remove_department
+      begin
+        DepartmentPractice.where(department_id: params[:id]).map { |dp| dp.destroy! }
+        Department.find(params[:id]).destroy!
+        true
+      rescue => e
+        Rails.logger.error "remove_department error: #{e.message}"
+        e
+      end
+    end
   end
 end


### PR DESCRIPTION
### JIRA issue link
[DM-2201](https://agile6.atlassian.net/browse/DM-2201)

## Description - what does this code do?
This PR fixes the admin's ability in the admin panel to delete departments that have a practice associated with them.

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as a admin.
2. Edit a practice's departments on the Overview page.
3. Go to the admin panel's department page.
4. Ensure you can delete the department that you assigned to the  practice in Step 2.
5. Ensure you see a notice saying the Department was successfully deleted.
BONUS: Make sure when you delete a category in the admin panel you also see a notice saying the Category was successfully deleted.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs