### PR TITLE
DM-2176: Add explore all practices page

### DIFF
--- a/app/assets/javascripts/_explore.es6
+++ b/app/assets/javascripts/_explore.es6
@@ -1,0 +1,36 @@
+(($) => {
+  const $document = $(document);
+  const catBtn = '.dm-category-btn';
+  const seeAllBtn = '.dm-see-all-btn';
+
+  function setSortDefault() {
+    $('#dm_sort_option').val('a_to_z');
+  }
+
+  function attachCategoryBtnEventListener() {
+    $(catBtn).on('click', function(e) {
+      if ($(e.target).hasClass('dm-selected')) {
+        $(e.target).removeClass('dm-selected usa-button');
+        $(e.target).addClass('usa-button--outline');
+      } else {
+        $(e.target).addClass('dm-selected usa-button');
+        $(e.target).removeClass('usa-button--outline');
+      }
+    })
+  }
+
+  function attachShowAllCategoriesEventListener() {
+    $(seeAllBtn).on('click', function(e) {
+      $('.dm-see-more').removeClass('display-none');
+      $(e.target).addClass('display-none');
+    })
+  }
+
+  function setExplorePage () {
+    setSortDefault();
+    attachCategoryBtnEventListener();
+    attachShowAllCategoriesEventListener();
+  }
+
+  $document.on('turbolinks:load', setExplorePage);
+})(window.jQuery);

--- a/app/assets/stylesheets/dm/_classes.scss
+++ b/app/assets/stylesheets/dm/_classes.scss
@@ -16,7 +16,7 @@ to confirm the class DOES NOT EXIST before adding a new class
 @import "variables/colors";
 
 .dm-primary-5v-background {
-  background-color: $dm-color-primary-5v !important;
+  background-color: $dm-color-blue-5v !important;
 }
 
 /* Linear Gradient backgrounds */

--- a/app/assets/stylesheets/dm/components/_practice_card.scss
+++ b/app/assets/stylesheets/dm/components/_practice_card.scss
@@ -2,8 +2,6 @@
 
 .dm-practice-card {
   position: relative;
-  min-width: 309px;
-  max-width: 309px;
   max-height: 436px;
 
   .dm-practice-link {
@@ -60,6 +58,7 @@
 
   .dm-practice-card-container {
     height: 412px;
+    min-width: 309px;
     max-width: 309px;
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   }
@@ -93,6 +92,7 @@
     position: absolute;
     bottom: 12px;
     margin-right: 24px;
+    max-width: 278px;
 
     span {
       height: 30px;

--- a/app/assets/stylesheets/dm/components/_practice_card.scss
+++ b/app/assets/stylesheets/dm/components/_practice_card.scss
@@ -58,9 +58,12 @@
 
   .dm-practice-card-container {
     height: 412px;
-    min-width: 309px;
     max-width: 309px;
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+
+    @media screen and (min-width: 340px) {
+      min-width: 309px;
+    }
   }
 
   .dm-practice-card-img-container {

--- a/app/assets/stylesheets/dm/components/_profile.scss
+++ b/app/assets/stylesheets/dm/components/_profile.scss
@@ -43,7 +43,7 @@
    
   &:hover {
     text-decoration: none !important;
-    color: #1a4480 !important;
+    color: $dm-color-blue-70v !important;
   }
 
   .edit-profile-icon {

--- a/app/assets/stylesheets/dm/components/_side-nav.scss
+++ b/app/assets/stylesheets/dm/components/_side-nav.scss
@@ -1,3 +1,5 @@
+@import "../variables/colors";
+
 #sticky-wrapper {
   z-index: 1000;
 }
@@ -14,7 +16,7 @@
   cursor: pointer;
 
   &:hover {
-    background-color: #f0f0f0;
+    background-color: $dm-color-gray-5;
     color: #005ea2;
   }
 }

--- a/app/assets/stylesheets/dm/pages/_explore.scss
+++ b/app/assets/stylesheets/dm/pages/_explore.scss
@@ -11,7 +11,6 @@
   }
 
   .dm-results-count {
-    display: flex;
     align-items: center;
   }
 
@@ -28,6 +27,10 @@
   .dm-practice-card {
     &:first-child {
       padding-top: 0;
+
+      .dm-practice-bookmark-btn {
+        top: 8px;
+      }
     }
   }
 
@@ -68,10 +71,26 @@
     }
   }
 
+  @media screen and (min-width: 690px) {
+    .dm-practice-card {
+      &:nth-child(2) {
+        padding-top: 0px;
+
+        .dm-practice-bookmark-btn {
+          top: 8px;
+        }
+      }
+    }
+  }
+
   @media screen and (min-width: 1024px) {
     .dm-practice-card {
-      &:nth-child(2), &:nth-child(3) {
+      &:nth-child(3) {
         padding-top: 0px;
+
+        .dm-practice-bookmark-btn {
+          top: 8px;
+        }
       }
     }
 

--- a/app/assets/stylesheets/dm/pages/_explore.scss
+++ b/app/assets/stylesheets/dm/pages/_explore.scss
@@ -1,0 +1,84 @@
+// styles for /explore
+@import '../variables/colors';
+
+.dm-explore-practices {
+  // need the next two properties to remove weird whitespace below header
+  top: -1px;
+  position: relative;
+
+  .bg-primary-darker {
+    height: 160px;
+  }
+
+  .dm-results-count {
+    display: flex;
+    align-items: center;
+  }
+
+  .dm-category-btn {
+    border-radius: 100px;
+  }
+
+  .dm-load-more-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .dm-practice-card {
+    &:first-child {
+      padding-top: 0;
+    }
+  }
+
+  .dm-error-state {
+    height: 53px;
+
+    i, span {
+      position: absolute;
+    }
+
+    i {
+      font-size: 160px;
+      color: $dm-color-gray-5;
+      z-index: 0;
+    }
+
+    span {
+      width: 308px;
+      height: 53px;
+      z-index: 1;
+    }
+  }
+
+  .dm-loading-spinner {
+    .fa-circle-notch {
+      color: $dm-color-blue-70v;
+      font-size: 40px;
+      animation: rotation 1s infinite linear;
+    }
+
+    @keyframes rotation {
+      from {
+        transform: rotate(0deg);
+      }
+      to {
+        transform: rotate(360deg);
+      }
+    }
+  }
+
+  @media screen and (min-width: 1024px) {
+    .dm-practice-card {
+      &:nth-child(2), &:nth-child(3) {
+        padding-top: 0px;
+      }
+    }
+
+    .dm-sort-container {
+      // need this to make sure sort select is all the way to the right
+      left: 8px;
+      top: 8px;
+    }
+  }
+}

--- a/app/assets/stylesheets/dm/pages/_practice.scss
+++ b/app/assets/stylesheets/dm/pages/_practice.scss
@@ -28,11 +28,11 @@
   }
 
   .dm-tab {
-    border-bottom: 1px solid #F0F0F0;
+    border-bottom: 1px solid $dm-color-gray-5;
     font-weight: normal;
 
     &.top-tab {
-      border-top: 1px solid #F0F0F0;
+      border-top: 1px solid $dm-color-gray-5;
     }
 
     // &.bottom-tab {
@@ -200,11 +200,6 @@
   margin-right: 8px;
 }
 
-.conversation-line {
-  height: 2px;
-  border: 2px solid #F0F0F0;
-}
-
 .impact-image {
   height: 263px;
   width: 393px;
@@ -301,7 +296,7 @@
 
   &:hover {
     text-decoration: none !important;
-    color: #1a4480 !important
+    color: $dm-color-blue-70v !important
   }
 }
 

--- a/app/assets/stylesheets/dm/variables/_colors.scss
+++ b/app/assets/stylesheets/dm/variables/_colors.scss
@@ -4,12 +4,17 @@ $dm-color-gray-80: #2e2e2e;
 $dm-color-gray-60: #5c5c5c;
 $dm-color-gray-30: #adadad;
 $dm-color-gray-20: #c9c9c9;
+$dm-color-gray-5: #f0f0f0;
 $dm-color-gray-2: #f9f9f9;
-$dm-color-blue-20v: #a1d3ff; // covid-19 banner background color
-$dm-color-blue-30v: #81AEFC;
-$dm-color-blue-50v: #0076d6;
-$dm-color-blue-70v: #0b4778;
-$dm-color-blue-80v: #112f4e;
+
+// Blue warm vivid - https://designsystem.digital.gov/design-tokens/color/system-tokens/#blue-warm
+$dm-color-blue-5v: #edf5ff;
+$dm-color-blue-20v: #adcdff;
+$dm-color-blue-30v: #81aefc; // primary-light
+$dm-color-blue-50v: #2672de;
+$dm-color-blue-70v: #1a4480; // primary-dark
+$dm-color-blue-80v: #162e51;
+
 $dm-color-red-50v: #e52207;
 $dm-color-red-60v: #b50909;
 $dm-color-red-70v: #8b0a03;
@@ -26,7 +31,6 @@ $dm-default-visited-purple: #562b97;
 
 // homepage map
 $dm-color-dark-black: #171717;
-$dm-color-primary-5v: #EDF5FF;
 $dm-color-lighter-grey: #DCDEE0;
 
 // TODO: can probably clean up once new designs in place

--- a/app/assets/stylesheets/dm_uswds/theme/_uswds-theme-custom-styles.scss
+++ b/app/assets/stylesheets/dm_uswds/theme/_uswds-theme-custom-styles.scss
@@ -31,6 +31,11 @@ $theme-breadcrumb-min-width: 'mobile';
   box-sizing: border-box;
 }
 
+.grid-container {
+  padding-left: 24px;
+  padding-right: 24px;
+}
+
 /****************************************
   BUTTONS
 *****************************************/

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,7 +1,7 @@
 class HomeController < ApplicationController
 
   def index
-    @practices = Practice.searchable_practices
+    @practices = Practice.searchable_practices 'a_to_z'
     @favorite_practices = current_user&.favorite_practices || []
     @facilities_data = facilities_json
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -117,7 +117,7 @@ class UsersController < ApplicationController
       )
 
       # Practices based on the user's location
-      @practices = Practice.searchable_practices
+      @practices = Practice.searchable_practices 'a_to_z'
       @facilities_data = facilities_json
       @offices_data = origin_data_json
       @user_location_practices = []

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -62,6 +62,10 @@ module NavigationHelper
         session[:breadcrumbs] << {'display': 'Practices', 'path': '/practices'}
       end
 
+      if action == 'explore'
+        empty_breadcrumbs
+      end
+
       search_breadcrumb = session[:breadcrumbs].find { |bc| bc['display'] == 'Search' || bc[:display] == 'Search' } || nil
       url = URI::parse(request.referer || '')
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -7,7 +7,7 @@ class Category < ApplicationRecord
   has_many :practices, through: :categories
   has_many :practices, through: :category_practices
 
-  scope :with_practices,   -> { joins(:category_practices).where.not(categories: {name: 'Other', is_other: true}).order(Arel.sql("lower(name) ASC")).uniq }
+  scope :with_practices,   -> { joins(:practices).where.not(categories: {name: 'Other', is_other: true}).where(practices: {approved: true, published: true, enabled: true} ).order(Arel.sql("lower(categories.name) ASC")).uniq }
 
   attr_accessor :related_terms_raw
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -7,6 +7,8 @@ class Category < ApplicationRecord
   has_many :practices, through: :categories
   has_many :practices, through: :category_practices
 
+  scope :with_practices,   -> { joins(:category_practices).where.not(categories: {name: 'Other', is_other: true}).order(Arel.sql("lower(name) ASC")).uniq }
+
   attr_accessor :related_terms_raw
 
   def related_terms_raw

--- a/app/models/category_practice.rb
+++ b/app/models/category_practice.rb
@@ -1,4 +1,11 @@
 class CategoryPractice < ApplicationRecord
   belongs_to :category
   belongs_to :practice
+
+  after_save :clear_searchable_practices_cache
+  after_destroy :clear_searchable_practices_cache
+
+  def clear_searchable_practices_cache
+    practice.clear_searchable_cache
+  end
 end

--- a/app/models/diffusion_history.rb
+++ b/app/models/diffusion_history.rb
@@ -1,6 +1,8 @@
 class DiffusionHistory < ApplicationRecord
   belongs_to :practice
   has_many :diffusion_history_statuses, dependent: :destroy
+  after_save :clear_searchable_practices_cache
+  after_destroy :clear_searchable_practices_cache
 
   attr_accessor :facility_name
 
@@ -8,5 +10,9 @@ class DiffusionHistory < ApplicationRecord
     facilities = JSON.parse(File.read("#{Rails.root}/lib/assets/vamc.json"))
     facility = facilities.find { |f| f['StationNumber'] == facility_id }
     facility['OfficialStationName']
+  end
+
+  def clear_searchable_practices_cache
+    practice.clear_searchable_cache
   end
 end

--- a/app/views/practices/_explore.js.erb
+++ b/app/views/practices/_explore.js.erb
@@ -13,7 +13,7 @@ function setExplorePracticesPage() {
 
 function filterCategoriesEventListener() {
   $(catBtn).on('click', function(e) {
-      displaySpinner({ isNextPage: false });
+    displaySpinner({ isNextPage: false });
     setDataAndMakeRequest({ isNextPage: false });
   })
 }

--- a/app/views/practices/_explore.js.erb
+++ b/app/views/practices/_explore.js.erb
@@ -1,0 +1,131 @@
+var sortOptions = ['a_to_z', 'adoptions', 'added'];
+var sortSelect = '#dm_sort_option';
+var catBtn = '.dm-category-btn';
+var loadMoreBtn = '.dm-load-more-btn';
+var loadMoreContainer = '.dm-load-more-container';
+
+function setExplorePracticesPage() {
+  setAjaxCSRFToken();
+  sortEventListener();
+  filterCategoriesEventListener();
+  loadMoreEventListener();
+}
+
+function filterCategoriesEventListener() {
+  $(catBtn).on('click', function(e) {
+      displaySpinner({ isNextPage: false });
+    setDataAndMakeRequest({ isNextPage: false });
+  })
+}
+
+function loadMoreEventListener() {
+  $(loadMoreBtn).on('click', function(e) {
+    displaySpinner({ isNextPage: true });
+    setDataAndMakeRequest({isNextPage: true});
+  })
+}
+
+function sortEventListener() {
+  $(sortSelect).on('change', function (e) {
+    displaySpinner({ isNextPage: false });
+    setDataAndMakeRequest({ isNextPage: false });
+  });
+}
+
+function displaySpinner(params = { isNextPage }) {
+  $('.dm-results-count').addClass('display-none');
+  $('.dm-error-state').addClass('display-none');
+  $('.dm-loading-spinner').removeClass('display-none');
+  $('.dm-loading-spinner').addClass('display-flex');
+
+  if (params.isNextPage) {
+    $(loadMoreContainer).addClass('display-none');
+    $('.dm-load-more-btn').addClass('display-none');
+  } else {
+    $('.dm-practice-card-section').addClass('display-none');
+  }
+}
+
+function hideSpinner() {
+  $('.dm-loading-spinner').addClass('display-none');
+  $('.dm-loading-spinner').removeClass('display-flex');
+  $('.dm-practice-card-section').removeClass('display-none');
+}
+
+function setDataAndMakeRequest(params = { isNextPage }) {
+  var sortOption = $(sortSelect).val() || 'a_to_z';
+  var categories = setCategories();
+  var page = $(loadMoreBtn).data('next') || null;
+  var data = { sort_option: sortOption };
+
+  if (categories.length > 0) {
+    data.categories = categories;
+  }
+
+  if (params.isNextPage && page !== null) {
+    data.page = page;
+  }
+  sendAjaxRequest(data);
+}
+
+function setCategories() {
+  var selectedBtns = $('.dm-selected');
+  var selectedIds = [];
+  for (var i = 0; i < selectedBtns.length; i++) {
+    var catId = $(selectedBtns[i]).data('catId');
+    selectedIds.push(catId);
+  }
+  return  selectedIds;
+}
+
+function setAjaxCSRFToken() {
+  $.ajaxSetup({
+    headers: {
+      'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
+    }
+  });
+}
+
+function sendAjaxRequest(data) {
+  var countText;
+
+  $.ajax({
+    type: 'POST',
+    dataType: 'json',
+    data: data,
+    url: '/explore',
+    success: function(result) {
+      countText = result.count + ' result' + (result.count == 1 ? ':' : 's:');
+      if (data.page == undefined) {
+        $('#dm-practice-card-list').empty();
+      }
+      $('#dm-practice-card-list').append(result.practice_cards_html);
+      $('.dm-results-count').removeClass('display-none');
+      if ( result.next !== null ) {
+        $(loadMoreContainer).removeClass('display-none');
+        $(loadMoreContainer).empty();
+        $('.dm-load-more-container').append('<button name="button" type="button" class="usa-button--outline dm-btn-base dm-load-more-btn width-auto" data-next="' + result.next + '">Load more</button>');
+        loadMoreEventListener();
+      } else {
+        $(loadMoreContainer).empty();
+        $(loadMoreContainer).addClass('display-none');
+      }
+    },
+    error: function(result) {
+      $('#dm-practice-card-list').addClass('display-none');
+      $('.dm-error-state').removeClass('display-none');
+      $(loadMoreContainer).empty();
+      $(loadMoreContainer).addClass('display-none');
+      countText = '0 results:'
+    },
+    complete: function(result) {
+      $('.dm-results-count').text(countText);
+      $('.dm-results-count').removeClass('display-none');
+      hideSpinner();
+    }
+  });
+}
+
+document.addEventListener('turbolinks:load', function () {
+    setExplorePracticesPage();
+});

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -89,7 +89,7 @@ function searchPracticesPage() {
     function highlighter(resultItem) {
         resultItem.matches.forEach(function (matchItem) {
             // don't highlight if match was on category since category is not in practice search result text and can't be highlighted
-            if (matchItem.key != 'categories_name') {
+            if (matchItem.key != 'category_names') {
                 var text = resultItem.item[matchItem.key];
                 var result = [];
                 var matches = [].concat(matchItem.indices); // limpar referencia
@@ -122,7 +122,7 @@ function searchPracticesPage() {
 
     // Set Fuse.js search options
     var search_options = {
-        keys: ['name', 'tagline', 'description', 'summary', 'initiating_facility', 'categories_name', 'maturity_level'],
+        keys: ['name', 'tagline', 'description', 'summary', 'initiating_facility', 'category_names', 'maturity_level'],
         minMatchCharLength: 1,
         tokenize: true,
         shouldSort: true,

--- a/app/views/practices/explore.html.erb
+++ b/app/views/practices/explore.html.erb
@@ -35,8 +35,10 @@
       <% end%>
     </div>
     <div class="grid-row margin-bottom-3 desktop:margin-bottom-1 margin-top-05">
-      <div class="grid-col-12 desktop:grid-col-6 dm-results-count display-flex flex-align-center">
-        <%= "#{@pr_count} result#{@pr_count == 1 ? ':' : 's:'}" %>
+      <div class="grid-col-12 desktop:grid-col-6 display-flex flex-align-center">
+        <span class="dm-results-count">
+          <%= "#{@pr_count} result#{@pr_count == 1 ? ':' : 's:'}" %>
+        </span>
       </div>
       <div class="grid-col-12 desktop:grid-col-6 order-first desktop:order-last margin-bottom-3 margin-top-1 desktop:margin-top-0 dm-sort-container">
         <%= label_tag 'dm_sort_option', '', class: 'usa-label margin-0' %>

--- a/app/views/practices/explore.html.erb
+++ b/app/views/practices/explore.html.erb
@@ -1,0 +1,68 @@
+<% provide :head_tags do %>
+  <%= javascript_include_tag '_practice_utilities', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_include_tag '_explore', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
+    <%= render partial: 'explore', formats: [:js] %>
+  <% end %>
+<% end %>
+
+<%
+  sort_options = [
+    ['- Sort by -', nil, selected: false, disabled: true, class: 'usa-select'],
+    ['Sort by A to Z', 'a_to_z', class: 'usa-select'],
+    ['Sort by most adoptions', 'adoptions', class: 'usa-select'],
+    ['Sort by most recently added', 'added', class: 'usa-select']
+  ]
+%>
+
+<div class="dm-explore-practices">
+  <div class="bg-primary-darker padding-4 display-flex flex-align-center flex-justify-center">
+    <h1 class="text-white text-center margin-0 line-height-sans-4">Explore all practices</h1>
+  </div>
+  <div class="grid-container padding-x-2 padding-top-3">
+    <div class="grid-row">
+      <% @categories.each_with_index do |cat, index| %>
+        <% if index < 5 %>
+          <%= button_tag "#{cat.name}", type: 'button', class: "width-auto usa-button--outline dm-btn-primary margin-bottom-2 dm-category-btn", data: { cat_id: cat.id } %>
+          <% else %>
+          <div class="dm-see-more display-none desktop:display-block">
+            <%= button_tag "#{cat.name}", type: 'button', class: "width-auto usa-button--outline dm-btn-primary margin-bottom-2 dm-category-btn", data: { cat_id: cat.id } %>
+          </div>
+        <% end %>
+      <% end %>
+      <% if @categories.count > 5 %>
+        <%= button_tag "See all categories", type: 'button', class: "usa-button--unstyled dm-btn-primary dm-see-all-btn desktop:display-none margin-bottom-2" %>
+      <% end%>
+    </div>
+    <div class="grid-row margin-bottom-3 desktop:margin-bottom-1 margin-top-05">
+      <div class="grid-col-12 desktop:grid-col-6 dm-results-count display-flex flex-align-center">
+        <%= "#{@pr_count} result#{@pr_count == 1 ? ':' : 's:'}" %>
+      </div>
+      <div class="grid-col-12 desktop:grid-col-6 order-first desktop:order-last margin-bottom-3 margin-top-1 desktop:margin-top-0 dm-sort-container">
+        <%= label_tag 'dm_sort_option', '', class: 'usa-label margin-0' %>
+        <%= select_tag('', options_for_select(sort_options), id: 'dm_sort_option', name: 'sort_option', class: 'height-5 usa-select margin-0') %>
+      </div>
+    </div>
+    <div class="dm-error-state display-flex flex-align-center flex-justify-center text-center margin-y-10 display-none">
+      <i class="fas fa-heart-broken"></i>
+      <span class="line-height-25px">Oops! Looks like an error occured fetching practices. Please try again later.</span>
+    </div>
+    <div class="dm-practice-card-section">
+      <% if @practices.any? %>
+        <div id="dm-practice-card-list" class="grid-row grid-gap-3">
+          <% @practices.each do |practice| %>
+              <%= render partial: 'shared/practice_card', locals: { practice: practice} %>
+          <% end %>
+        </div>
+      <% end %>
+      <div class="grid-row dm-load-more-container padding-top-2">
+        <% if @pagy_info.next %>
+          <%= button_tag "Load more", type: 'button', class: "usa-button--outline dm-btn-base dm-load-more-btn width-auto", data: { next: @pagy_info.next } %>
+        <% end %>
+      </div>
+    </div>
+    <div class="dm-loading-spinner display-none flex-justify-center flex-align-self-center margin-y-4">
+      <i class="fas fa-circle-notch"></i>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_practice_card.html.erb
+++ b/app/views/shared/_practice_card.html.erb
@@ -1,4 +1,4 @@
-<div class="dm-practice-card grid-col-12 tablet:grid-col-6 desktop:grid-col-4 padding-y-105">
+<div class="dm-practice-card padding-y-105">
   <% if current_user %>
     <%= link_to practice_favorite_path(practice, format: :js), method: :post, remote: true, 'title': "Bookmark #{practice.name}", 'aria-label': "Bookmark #{practice.name}", 'tabindex': '-1', 'aria-hidden': 'true', 'class': "dm-practice-bookmark-btn", 'id': "dm-bookmark-button-#{practice.id}" do %>
       <i class="<% if current_user.favorite_practice_ids.include?(practice.id) %>fas fa-bookmark<% else %>far fa-bookmark<% end %> dm-favorite-icon-<%= practice.id %>"></i>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -21,6 +21,7 @@ Rails.application.config.assets.precompile += %w(
                                                   _introduction_image_editor.js
                                                   _overview_image_editor.js
                                                   _usa_file_input.js
+                                                  _explore.js
                                                   practice_editor_contact.js
                                                   practice_editor_timeline.js
                                                   practice_editor_origin.js

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,8 @@ Rails.application.routes.draw do
   get 'practices/planning_checklist' => 'practices#planning_checklist'
   get 'pii_phi_information' => 'home#pii_phi_information'
   get '/search' => 'practices#search'
+  get '/explore' => 'practices#explore'
+  post '/explore' => 'practices#explore_practices'
 
   get '/users/:id' => 'users#show'
   get '/edit-profile' => 'users#edit_profile'

--- a/spec/features/explore_spec.rb
+++ b/spec/features/explore_spec.rb
@@ -1,0 +1,223 @@
+require 'rails_helper'
+
+describe 'Explore all practices page', type: :feature do
+  before do
+    cat_1 = Category.create!(name: 'COVID')
+    cat_2 = Category.create(name: 'Telehealth')
+    cat_3 = Category.create!(name: 'Other')
+    cat_4 = Category.create!(name: 'Other Subcategory', is_other: true)
+
+    practice_names = ['Cards for Memory', 'BIONE', 'GLOW3', 'Beach VA', 'Virtual Care', 'COPD', 'GERIVETZ', 'Gerofit', 'Pink Gloves Program', 'SOAR', 'Project Happenings', 'REVAMP', 'Telemedicine', 'Different practice']
+    @practices = []
+    practice_names.each do |name|
+      @practices.push(Practice.create!(name: name, approved: true, published: true, tagline: "Tagline for #{name}", support_network_email: 'test@test.com'))
+    end
+    Practice.create!(name: 'Unpublished practice', approved: false, published: false)
+
+    @practices.each_with_index do |pr, index|
+      if pr.name == 'Different practice'
+        CategoryPractice.create!(practice: pr, category: cat_3)
+        CategoryPractice.create!(practice: pr, category: cat_4)
+      elsif index < 6
+        CategoryPractice.create!(practice: pr, category: cat_1)
+      elsif index >= 6
+        CategoryPractice.create!(practice: pr, category: cat_2)
+      end
+    end
+
+    dh_1 = DiffusionHistory.create!(practice_id: @practices[0].id, facility_id: '516')
+    DiffusionHistoryStatus.create!(diffusion_history_id: dh_1.id, status: 'Completed')
+    dh_2 = DiffusionHistory.create!(practice_id: @practices[0].id, facility_id: '600GC')
+    DiffusionHistoryStatus.create!(diffusion_history_id: dh_2.id, status: 'Completed')
+    dh_3 = DiffusionHistory.create!(practice_id: @practices[3].id, facility_id: '516')
+    DiffusionHistoryStatus.create!(diffusion_history_id: dh_3.id, status: 'Completed')
+    dh_4 = DiffusionHistory.create!(practice_id: @practices[4].id, facility_id: '516')
+    DiffusionHistoryStatus.create!(diffusion_history_id: dh_4.id, status: 'Completed')
+  end
+
+  describe 'Page content' do
+    it 'should display the correct default content' do
+      visit '/explore'
+      expect(page).to have_content('COVID')
+      expect(page).to have_content('Telehealth')
+      expect(page).to have_content('14 results')
+      page.has_button?('Load more')
+      expect(page).to have_no_content('Other')
+      expect(page).to have_no_content('Other Subcategory')
+      expect(page).to have_no_css('.dm-selected')
+      expect(page).to have_select('dm_sort_option', selected: 'Sort by A to Z')
+      expect(page).to have_content('14 results')
+      expect(find_all('.dm-practice-title')[0]).to have_text('Beach VA')
+      expect(find_all('.dm-practice-title')[1]).to have_text('BIONE')
+      expect(find_all('.dm-practice-title').last).to have_text('SOAR')
+      expect(page).to have_css('.dm-practice-card', count: 12)
+      find('.dm-load-more-btn').click
+      expect(page).to have_content('Virtual Care')
+      expect(find_all('.dm-practice-title').last).to have_text('Virtual Care')
+      expect(page).to have_css('.dm-practice-card', count: 14)
+      expect(page).to have_no_content('Unpublished practice')
+      page.has_no_button?('Load more')
+    end
+
+    it 'should sort the content by most adoptions' do
+      visit '/explore'
+      select 'Sort by most adoptions', from: 'dm_sort_option'
+      expect(page).to have_content('14 results')
+      page.has_button?('Load more')
+      expect(find_all('.dm-practice-title')[0]).to have_text('Cards for Memory')
+      expect(find_all('.dm-practice-title')[1]).to have_text('Beach VA')
+      expect(find_all('.dm-practice-title').last).to have_text('REVAMP')
+      expect(page).to have_css('.dm-practice-card', count: 12)
+      find('.dm-load-more-btn').click
+      expect(page).to have_css('.dm-practice-card', count: 14)
+      expect(find_all('.dm-practice-title').last).to have_text('Telemedicine')
+      page.has_no_button?('Load more')
+    end
+
+    it 'should sort the content by most recently created' do
+      visit '/explore'
+      select 'Sort by most recently added', from: 'dm_sort_option'
+      expect(page).to have_content('14 results')
+      page.has_button?('Load more')
+      expect(page).to have_content('GLOW3')
+      expect(find_all('.dm-practice-title')[0]).to have_text('Different practice')
+      expect(find_all('.dm-practice-title')[1]).to have_text('Telemedicine')
+      expect(find_all('.dm-practice-title').last).to have_text('GLOW3')
+      expect(page).to have_css('.dm-practice-card', count: 12)
+      find('.dm-load-more-btn').click
+      expect(page).to have_css('.dm-practice-card', count: 14)
+      expect(find_all('.dm-practice-title').last).to have_text('Cards for Memory')
+      page.has_no_button?('Load more')
+    end
+
+    it 'should filter by categories and allow for sorting' do
+      visit '/explore'
+      # filter by COVID category practices
+      expect(page).to have_no_css('.dm-selected')
+      find_all('.dm-category-btn')[0].click
+      expect(page).to have_css('.dm-selected', count: 1)
+      expect(page).to have_no_content('Different practice')
+      expect(page).to have_content('6 results')
+      expect(page).to have_css('.dm-practice-card', count: 6)
+      page.has_no_button?('Load more')
+      expect(find_all('.dm-practice-title')[0]).to have_text('Beach VA')
+      expect(find_all('.dm-practice-title')[1]).to have_text('BIONE')
+      expect(find_all('.dm-practice-title')[5]).to have_text('Virtual Care')
+      # sort by most adoptions
+      select 'Sort by most adoptions', from: 'dm_sort_option'
+      expect(page).to have_content('6 results')
+      expect(find_all('.dm-practice-title')[0]).to have_text('Cards for Memory')
+      expect(find_all('.dm-practice-title')[1]).to have_text('Beach VA')
+      expect(find_all('.dm-practice-title')[5]).to have_text('GLOW3')
+      # sort by most recently added
+      select 'Sort by most recently added', from: 'dm_sort_option'
+      expect(page).to have_content('6 results')
+      expect(find_all('.dm-practice-title')[0]).to have_text('COPD')
+      expect(find_all('.dm-practice-title')[1]).to have_text('Virtual Care')
+      expect(find_all('.dm-practice-title')[5]).to have_text('Cards for Memory')
+
+      # filter by COVID and Telehealth category practices
+      find_all('.dm-category-btn')[1].click
+      expect(page).to have_content('13 results')
+      expect(page).to have_css('.dm-selected', count: 2)
+      expect(page).to have_css('.dm-practice-card', count: 12)
+      page.has_button?('Load more')
+      expect(find_all('.dm-practice-title')[0]).to have_text('Telemedicine')
+      expect(find_all('.dm-practice-title')[1]).to have_text('REVAMP')
+      expect(find_all('.dm-practice-title')[11]).to have_text('BIONE')
+      # sort by A to Z
+      select 'Sort by A to Z', from: 'dm_sort_option'
+      expect(page).to have_content('13 results')
+      page.has_button?('Load more')
+      expect(find_all('.dm-practice-title')[0]).to have_text('Beach VA')
+      expect(find_all('.dm-practice-title')[1]).to have_text('BIONE')
+      expect(find_all('.dm-practice-title')[11]).to have_text('Telemedicine')
+      # sort by most adoptions
+      select 'Sort by most adoptions', from: 'dm_sort_option'
+      expect(page).to have_content('13 results')
+      page.has_button?('Load more')
+      expect(find_all('.dm-practice-title')[0]).to have_text('Cards for Memory')
+      expect(find_all('.dm-practice-title')[1]).to have_text('Beach VA')
+      expect(find_all('.dm-practice-title')[11]).to have_text('SOAR')
+      find('.dm-load-more-btn').click
+      expect(page).to have_content('Telemedicine')
+      expect(page).to have_no_content('Different practice')
+      expect(find_all('.dm-practice-title')[12]).to have_text('Telemedicine')
+      # refresh the page
+      visit current_path
+      # make sure the defaults are all set again
+      expect(page).to have_no_css('.dm-selected')
+      expect(page).to have_content('14 results')
+      expect(page).to have_css('.dm-practice-card', count: 12)
+      expect(page).to have_select('dm_sort_option', selected: 'Sort by A to Z')
+    end
+  end
+
+  describe 'cache' do
+    def cache_keys
+      Rails.cache.redis.keys
+    end
+
+    it 'should cache the practices and clear them on changes to the practice' do
+      admin = User.create!(email: 'sandy.cheeks@bikinibottom.net', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+      admin.add_role(User::USER_ROLES[1].to_sym)
+
+      pr = @practices[7]
+      pr.update(summary: 'test summary', date_initiated: Time.now())
+      PracticeOriginFacility.create!(practice: pr, facility_type: 0, facility_id: '687HA')
+
+      Rails.cache.clear
+      expect(cache_keys).not_to include("searchable_practices_a_to_z")
+      expect(cache_keys).not_to include("searchable_practices_added")
+      expect(cache_keys).not_to include("searchable_practices_adoptions")
+
+      visit explore_path
+      expect(cache_keys).to include("searchable_practices_a_to_z")
+      expect(cache_keys).not_to include("searchable_practices_added")
+      expect(cache_keys).not_to include("searchable_practices_adoptions")
+
+      select 'Sort by most adoptions', from: 'dm_sort_option'
+      sleep 1
+      expect(cache_keys).to include("searchable_practices_adoptions")
+
+      select 'Sort by most recently added', from: 'dm_sort_option'
+      sleep 1
+      expect(cache_keys).to include("searchable_practices_added")
+
+      login_as(admin, :scope => :user, :run_callbacks => false)
+      # cache clears when adding a practice category
+      visit practice_introduction_path(pr)
+      find('#category_covid_label').click # selects Telehealth
+      find('#practice-editor-save-button').click
+      sleep 1
+      expect(cache_keys).not_to include("searchable_practices_a_to_z")
+      expect(cache_keys).not_to include("searchable_practices_added")
+      expect(cache_keys).not_to include("searchable_practices_adoptions")
+      visit explore_path
+      expect(cache_keys).to include("searchable_practices_a_to_z")
+
+      # cache clears when adding an adoption
+      visit practice_adoptions_path(pr)
+      find('#add_adoption_button').click
+      find('label[for="status_unsuccessful"').click
+      select('Alaska', :from => 'editor_state_select')
+      select('Anchorage VA Medical Center', :from => 'editor_facility_select')
+      find('#adoption_form_submit').click
+      sleep 1
+      expect(cache_keys).not_to include("searchable_practices_a_to_z")
+      visit explore_path
+      expect(cache_keys).to include("searchable_practices_a_to_z")
+
+      # cache clears when removing an adoption
+      visit practice_adoptions_path(pr)
+      find("button[aria-controls='unsuccessful_adoptions'").click
+      find("button[aria-controls='diffusion_history_#{pr.diffusion_histories.first.id}']").click
+      within(:css, "#diffusion_history_#{pr.diffusion_histories.first.id}") do
+        click_link('Delete entry')
+      end
+      page.accept_alert
+      sleep 1
+      expect(cache_keys).not_to include("searchable_practices_a_to_z")
+    end
+  end
+end

--- a/spec/features/explore_spec.rb
+++ b/spec/features/explore_spec.rb
@@ -6,13 +6,16 @@ describe 'Explore all practices page', type: :feature do
     cat_2 = Category.create(name: 'Telehealth')
     cat_3 = Category.create!(name: 'Other')
     cat_4 = Category.create!(name: 'Other Subcategory', is_other: true)
+    cat_5 = Category.create!(name: 'Main Level Cat')
 
     practice_names = ['Cards for Memory', 'BIONE', 'GLOW3', 'Beach VA', 'Virtual Care', 'COPD', 'GERIVETZ', 'Gerofit', 'Pink Gloves Program', 'SOAR', 'Project Happenings', 'REVAMP', 'Telemedicine', 'Different practice']
     @practices = []
     practice_names.each do |name|
       @practices.push(Practice.create!(name: name, approved: true, published: true, tagline: "Tagline for #{name}", support_network_email: 'test@test.com'))
     end
-    Practice.create!(name: 'Unpublished practice', approved: false, published: false)
+
+    pr_1 = Practice.create!(name: 'Unpublished practice', approved: false, published: false)
+    CategoryPractice.create!(practice: pr_1, category: cat_5)
 
     @practices.each_with_index do |pr, index|
       if pr.name == 'Different practice'
@@ -40,6 +43,7 @@ describe 'Explore all practices page', type: :feature do
       visit '/explore'
       expect(page).to have_content('COVID')
       expect(page).to have_content('Telehealth')
+      expect(page).to have_no_content('Main Level Cat')
       expect(page).to have_content('14 results')
       page.has_button?('Load more')
       expect(page).to have_no_content('Other')

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -153,17 +153,17 @@ describe 'Search', type: :feature do
     it 'Should be reset if certain practice attributes have been updated' do
       add_search_to_cache
 
-      expect(cache_keys).to include("searchable_practices")
+      expect(cache_keys).to include("searchable_practices_a_to_z")
 
       update_practice_introduction(@practice)
 
-      expect(cache_keys).to include("searchable_practices")
+      expect(cache_keys).not_to include("searchable_practices_a_to_z")
     end
 
     it 'Should be reset if a new practice is created through the admin panel' do
       add_search_to_cache
 
-      expect(cache_keys).to include("searchable_practices")
+      expect(cache_keys).to include("searchable_practices_a_to_z")
 
       login_as(@admin, :scope => :user, :run_callbacks => false)
       visit '/admin'
@@ -178,7 +178,7 @@ describe 'Search', type: :feature do
       expect(page).to_not have_content(latest_practice.name)
       publish_practice(latest_practice)
       sleep 1
-      expect(cache_keys).to include("searchable_practices")
+      expect(cache_keys).not_to include("searchable_practices_a_to_z")
       # expect(Practice.searchable_practices.last.name).to eq(latest_practice.name)
       # visit '/search?=newest'
       # expect(page).to have_content('1 result for newest')

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -156,7 +156,7 @@ describe 'Search', type: :feature do
       expect(cache_keys).to include("searchable_practices_a_to_z")
 
       update_practice_introduction(@practice)
-
+      sleep 2
       expect(cache_keys).not_to include("searchable_practices_a_to_z")
     end
 


### PR DESCRIPTION
### JIRA issue link
[DM-2176](https://agile6.atlassian.net/browse/DM-2176)

## Description - what does this code do?
This PR adds functionality for the "Explore all practices" page.
In addition, this PR also addresses the following:
- practice card styling changes - on desktop view, practice cards take up full width of the container
- scss color variable update
- caches practices based on 3 sorting options
- resets the cache when a `CategoryPractice` and `DiffusionHistory` are updated/deleted

## Testing done - how did you test it/steps on how can another person can test it 
**Explore all practices**
1. Visit `/explore`
2. Ensure you do not see any breadcrumbs from previous site navigation
3. When first loading or reloading the "Explore all practices" page, check the following:
- no categories are selected
- the sort option is set to "Sort by A to Z"
- the total results count = total number of published practices in your local DB
- only first 12 practices in ABC order should be displayed
- if you have more than 12 practices, there is a load more button
- "Other" and subcategories of the "Other" category are not displayed as a filter option
- Categories that have not been selelcted by a practice are not displayed as a filter option
4. After clicking a category, check the following:
- a page spinner appears where the practice cards were (the results count and any load more buttons should not be visible)
- when the results load, the practice should be sorted based on the selected sorting option
- when selecting other categories, the results should be additive and the results count should update accordingly
- for category filter selection with more than 12 results, there should be a load more button
- changing the sort option only sorts the practices that are filtered out by then categories filter
- NOTE: if a practice is a part of two or multiple categories that you selected, it is only counted once towards the total results count
5. After selecting a new sort option, check the following:
- a page spinner appears where the practice cards were (the results count and any load more buttons should not be visible)
- the results count remain the same when only sorting the results
6. After clicking the "Load More" button, check the following:
- the remaining results should also be sorted according to the sort option selected
- the results are loaded 12 at a time
- when the final practices have all been loaded, there should be no "Load more" button
- If you have more than 24 practices, there should be another "Load more" button and so forth...
7. On the mobile version, check the following:
- if you have more than 5 categories, there is a "See all categories" link button
- When clicking the "See all categories" link button, it displays all the remaining categories
BONUS:
- In the code, go to the `app/views/practices/_explore.js.erb` file.
- Go to line `96`
- change the `url`value to something completely wrong like `/explore-bad-path`
- Reload the page
- Select a new sort option
- You should see an error message (see screenshots below)

**Practices caching**
1. Clear the cache in the rails console:`Rails.cache.clear`
2. Check that the keys don't exist: `Rails.cache.redis.keys`
3. Go to `/` or `/explore`
4. Check that the `searchable_practices_a_to_z` key now exists
5. Go to `/explore`
6. Select the other two sorting options
7. Check that the `searchable_practices_added` `searchable_practices_adoptions` keys now exists
8. Edit a practice and save
9. Check that the keys don't exist: `Rails.cache.redis.keys`
10. Repeat steps 3-7
11. Remove or add a category to a practice
12. Repeat steps 3-7
13. Remove, add, or edit a diffusion history for a practice
14. Repeat steps 3-7

**Practice card styling**
1. Go to various pages where there are practice cards (e.g. Profile, Recommend for you, page builder pages with practices, explore all practices, home page, etc...)
2. Ensure the cards are to-design
3. Most noticeable would be home page and explore all practices page (the row of practice cards width matches the other elements on that page that take up the full width of the container)

## Screenshots, Gifs, Videos from application (if applicable)
**Explore all practices (default)**
<img width="1703" alt="Screen Shot 2020-12-01 at 5 21 55 PM" src="https://user-images.githubusercontent.com/20211771/100808551-f7ab3d00-33f9-11eb-875f-e6470556608a.png">

**Load more**
<img width="1702" alt="Screen Shot 2020-12-01 at 5 23 33 PM" src="https://user-images.githubusercontent.com/20211771/100808570-009c0e80-33fa-11eb-96de-baceb4002d66.png">


**Error Message**
<img width="1702" alt="Screen Shot 2020-12-01 at 5 22 27 PM" src="https://user-images.githubusercontent.com/20211771/100808506-e6fac700-33f9-11eb-8ca2-5105328ac63d.png">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
[Figma](https://www.figma.com/file/y9U9oLXTGe24O9W3X5UoYW/Home-%2B-Search-V2?node-id=480%3A17203)

## Acceptance criteria
- [X] Build mobile first
- [X] User can select a category
- [X] List of categories is here (didn't write a script since this is already on prod)  
- [X] Additive search results when multiple categories are selected
- [X] Initial display loads 12
- [X] Initial display is A-Z
- [X] Load More button loads 12 more
- [X] Sorting updates practices immediately
- [X] If navigate away and come back, none of filter or sorts are still there
- [X] If you go to select a different dropdown, there’s a check next to what is selected and hover has blue color
- [X] Sorting: Most Adoptions, A-Z, Date Added
- [X] Use new handoff flow
- [X] URL is “/explore”

## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs