### PR TITLE
DM-2246: Extend s3 expiration for presigned urls

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -6,7 +6,7 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def s3_presigned_url(path)
-    signer.presigned_url(:get_object, bucket: ENV['S3_BUCKET_NAME'], key: path )
+    signer.presigned_url(:get_object, bucket: ENV['S3_BUCKET_NAME'], key: path, expires_in: 86400 ) # number of seconds in a day
   end
 
   def object_presigned_url(obj, style = nil)


### PR DESCRIPTION
### JIRA issue link
[DM-2246](https://agile6.atlassian.net/browse/DM-2246)

## Description - what does this code do?
This code extends the expiration time of the Amazon s3's presigned urls that our app generates from 900 seconds to 86400 seconds or 1 day.

## Testing done - how did you test it/steps on how can another person can test it 
1. Go to a practice with a file that can be downloaded.
2. Make sure the file can be opened and viewed
3. If you want, I guess you can see after a day if it expires haha 😅 or you can change the expires_in time to see that it expires correctly.
4. Try steps 1 - 2 for other practices as well

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs