### PR TITLE
dm-styling-fixes: Made a few styling changes after testing code in de…

### DIFF
--- a/app/assets/javascripts/_side_nav.js.coffee
+++ b/app/assets/javascripts/_side_nav.js.coffee
@@ -1,6 +1,6 @@
 $(document).on 'turbolinks:load', (e) ->
   $('.sticky').sticky topSpacing: 45
-  $('#dm-practice-nav').sticky {topSpacing: 40, zIndex: 10000, bottomSpacing: 279}
+  $('#dm-practice-nav').sticky {topSpacing: 40, zIndex: 10000, bottomSpacing: 520}
 
 $(document).on 'click', '.scroll-to', (e) ->
   $.scrollTo($(this).data('target'), 500, {offset: {top: -45}})

--- a/app/assets/javascripts/practice_page.es6
+++ b/app/assets/javascripts/practice_page.es6
@@ -137,20 +137,11 @@
             $(e.target).parent().click();
 
             $(`.${status}-status-modal-container`).removeClass('display-none');
-            // Disable pointer events underneath the modal
-            $('body').css('pointer-events', 'none');
-
-            // Allow modal close icon to be the only interactive element
-            $(`#close_${status}_status_modal`).css('pointer-events', 'auto');
         });
     }
 
     function closeAdoptionStatusModal(status) {
-        $(document).on('click', `#close_${status}_status_modal`, (e) => {
-            // Remove pointer-events styling
-            $('body').css('pointer-events', '');
-            $(e.target).css('pointer-events', '');
-
+        $(document).on('click', `#close_${status}_status_modal`, () => {
             $(`.${status}-modal-icon`).parent().focus();
             $(`.${status}-status-modal-container`).addClass('display-none');
         });

--- a/app/assets/stylesheets/dm/components/_modal.scss
+++ b/app/assets/stylesheets/dm/components/_modal.scss
@@ -21,6 +21,12 @@
   background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
 }
 
+.successful-status-modal-container, .in-progress-status-modal-container, .unsuccessful-status-modal-container {
+  @media screen and (min-width: 1024px) {
+    display: none;
+  }
+}
+
 .adoption-status-modal {
   position: fixed; /* Stay in place */
   z-index: 100000; /* Sit on top */
@@ -35,6 +41,7 @@
   .adoption-status-modal-content {
     // get the height of the modal and divide by two so it's in the middle of the screen
     top: calc(50vh - 80px);
+    border: 0;
 
     .fa-times-circle {
       font-size: 1.5em !important;


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
Fixes a few styling issues discovered when testing on the dev environment.

## Testing done - how did you test it/steps on how can another person can test it 
**_Practice Editor Side Nav_**
1. Log in as an admin and visit the practice editor introduction page of any practice.
2. Scroll down to the bottom of the page and make sure the side nav does not go past the `Return to top` link.

**_Adoption Status Modal Container_**
1. Visit the show page of any practice.
2. Use the Google Inspector tool to view the page at a width smaller than `1024px`.
3. Click on the question mark icon located in one of the three adoption status accordion buttons.
4. Make sure the modal appears as normal.
5. Now increase the screen width to `1024px` or greater and make sure the modal is no longer there.

**_Additional Changes_**
1. Removed unnecessary border on the modal itself.
2. Got rid of some `pointer-events` calls in the JavaScript that ended up being useless.

## Screenshots, Gifs, Videos from application (if applicable)
**_Side Nav Before Fix_**
![Screenshot (34)](https://user-images.githubusercontent.com/34111449/105061955-1320e480-5a48-11eb-9257-d2053ae51140.png)

**_Side Nav After Fix_**
![Screen Shot 2021-01-19 at 11 19 14 AM](https://user-images.githubusercontent.com/34111449/105062098-39df1b00-5a48-11eb-857e-e34d6d5efbb4.png)

**_Adoption Status Modal Before Fix_**
![](https://media.giphy.com/media/XySF9Z6UNfrVdifPj6/giphy.gif)

**_Adoption Status Modal After Fix_**
![](https://media.giphy.com/media/dkdiFgsPuw0JnyfXXV/giphy.gif)

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs