### PR TITLE
Dm 2293

### DIFF
--- a/app/assets/javascripts/search.es6
+++ b/app/assets/javascripts/search.es6
@@ -4,6 +4,10 @@ addEventListener('turbolinks:load', function () {
     $searchField.val(''); // clear form
     $('#dm-navbar-search-form').submit(function(e) {
         e.preventDefault();
-        window.location = `${location.protocol}//${location.host}/search?query=${encodeURI($searchField.val())}`;
+        var sUrl = `${location.protocol}//${location.host}/search`;
+        if(Boolean($searchField.val())){
+            sUrl += `?query=${encodeURI($searchField.val())}`;
+        }
+        window.location = sUrl;
     });
 });

--- a/app/views/practices/_search.js.erb
+++ b/app/views/practices/_search.js.erb
@@ -10,6 +10,7 @@ var SPINNER = '.dm-loading-spinner';
 var LOAD_MORE_CONTAINER = '.button-box';
 var SEARCH_RESULTS = '#search-results';
 var SORT_EL = '#search_sort_option';
+var isBlankSearch = false;
 // Add Namespace for scroll position
 var pagePosition = {
     original: 0,
@@ -200,7 +201,6 @@ function searchPracticesPage() {
             '<p><b>Score: ' + result.score + '</b></p>' +
             '-->'
         });
-
         if (results.length > 0) {
 
             // Hide sorting options if there's only 1 result
@@ -235,8 +235,14 @@ function searchPracticesPage() {
             if ($(NO_QUERY_CONTENT).hasClass('display-none')) {
                 $(NO_QUERY_CONTENT).removeClass('display-none');
             }
-            $('#no-query-p').addClass('display-none');
-            $('#no-query-results-p').removeClass('display-none');
+            if (isBlankSearch) {
+                $('#no-query-p').removeClass('display-none');
+                $('#no-query-results-p').addClass('display-none');
+            }
+            else{
+                $('#no-query-p').addClass('display-none');
+                $('#no-query-results-p').removeClass('display-none');
+            }
         }
     }
 
@@ -244,10 +250,9 @@ function searchPracticesPage() {
     function search(query, categories, originatingFacility, adoptingFacility) {
         // Trim whitespace from the query (can cause matching problems)
         query = query.trim();
-
+        isBlankSearch = !Boolean(query) && categories == undefined && originatingFacility == undefined && adoptingFacility == undefined ? true : false;
         // Set variables
         var resultsSummary = document.querySelector('#results-summary');
-
         // set the search page search bar input value
         searchField.value = query;
 

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -82,11 +82,7 @@
           Enter a search term or use the filters to find matching practices
         </p>
         <p id="no-query-results-p" class="position-absolute z-100 padding-bottom-4 line-height-26 text-center display-none">
-          <% if params[:query].blank? %>
-            Enter a search term or use the filters to find matching practices
-          <% else %>
             There are currently no matches for your search on the Marketplace.
-          <% end %>
         </p>
         <i class="fas fa-search no-search-query-icon position-absolute z-index-10 text-base-lightest"></i>
       </div>

--- a/app/views/practices/search.html.erb
+++ b/app/views/practices/search.html.erb
@@ -82,7 +82,11 @@
           Enter a search term or use the filters to find matching practices
         </p>
         <p id="no-query-results-p" class="position-absolute z-100 padding-bottom-4 line-height-26 text-center display-none">
-          There are currently no matches for your search on the Marketplace.
+          <% if params[:query].blank? %>
+            Enter a search term or use the filters to find matching practices
+          <% else %>
+            There are currently no matches for your search on the Marketplace.
+          <% end %>
         </p>
         <i class="fas fa-search no-search-query-icon position-absolute z-index-10 text-base-lightest"></i>
       </div>

--- a/app/views/shared/_navbar_search.html.erb
+++ b/app/views/shared/_navbar_search.html.erb
@@ -2,7 +2,7 @@
   <label class="usa-sr-only" for="basic-search-field-small">
     practice search
   </label>
-  <input class="usa-input" id="dm-navbar-search-field" type="search" name="search" title="Search practices " required>
+  <input class="usa-input" id="dm-navbar-search-field" type="search" name="search" title="Search practices ">
   <button id="dm-navbar-search-button" class="usa-button" type="submit">
     <span class="usa-sr-only">Search</span>
   </button>

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -147,6 +147,11 @@ describe 'Search', type: :feature do
   end
 
   describe 'results' do
+    it 'should display empty query and filters message' do
+      visit '/'
+      find('#dm-navbar-search-button').click
+      expect(page).to have_content('Enter a search term or use the filters to find matching practices')
+    end
     it 'should display certain text if no matches are found' do
       visit_search_page
       toggle_filters_accordion

--- a/spec/features/shared/header_spec.rb
+++ b/spec/features/shared/header_spec.rb
@@ -81,14 +81,6 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
       end
     end
 
-    it 'should prevent submit an empty string' do
-      find('#dm-navbar-search-button').click
-      # source https://stackoverflow.com/questions/17384428/testing-html-5-form-validations-when-using-simple-form-rails
-      message = find("#dm-navbar-search-field").native.attribute("validationMessage")
-      expect(message).to eq "Please fill out this field."
-      expect(page).to have_current_path(practice_overview_path(@practice))
-    end
-
     it 'should redirect to the search results page' do
       within('header.usa-header') do
         fill_in('dm-navbar-search-field', with: 'test')


### PR DESCRIPTION
### JIRA issue link
https://agile6.atlassian.net/browse/DM-2293

## Description - what does this code do?
Allows users to click the search icon from the top nav-bar  even if the search text is blank in order to navigate to the search page.

## Testing done - how did you test it/steps on how can another person can test it 
1.  Login or don't... and click on the blue search icon in the top nav bar.
![image](https://user-images.githubusercontent.com/60527788/105252497-61aaad80-5b32-11eb-99a1-4bd65b2be904.png)
2.  Verify that the search page does not contain any queries or filters and the text in the search results displays "Enter a search term or use the filters to find matching practices".  
![image](https://user-images.githubusercontent.com/60527788/105252771-f2818900-5b32-11eb-8052-7bd90536cbfb.png)

This text should display whenever there are no filters, originating or adopting locations, or queries supplied.  If search data is present (i.e., query, categories, originating location or adoption locations) and there are no results returned by the search the text in results area should say "There are currently no matches for your search on the Marketplace.".  i.e., 
![image](https://user-images.githubusercontent.com/60527788/105252800-07f6b300-5b33-11eb-85f7-8eaf5dd64a53.png)

3.  Add and Remove filters to test that all is working well with search.

## Link to mock-ups/mock ups (image file if you have it) (if applicable)
Figma: https://www.figma.com/file/y9U9oLXTGe24O9W3X5UoYW/Home-%2B-Search-V2?node-id=1%3A171


## Acceptance criteria
When box is blank, clicking on the search icon (magnifying glass) takes you to the search page

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs