### PR TITLE
DM-2369: Fix site and practice show visit counts

### DIFF
--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -7,15 +7,16 @@ ActiveAdmin.register_page "Dashboard" do
     before_action :set_dashboard_values
 
     def site_visits(start_time, end_time)
-      Ahoy::Event.where(name: 'Site visit').where("properties->>'ip_address' is not null").where(time: start_time..end_time).group("properties->>'ip_address'").count
+      # is_duplicate was added to "properties" to remove duplicate 'Site visit' and 'Practice show' counts as a result of turbolinks loading the page twice, triggering two ahoy_event to be saved
+      Ahoy::Event.where(name: 'Site visit').where("properties->>'ip_address' is not null").where("properties->>'is_duplicate' is null").where(time: start_time..end_time).group("properties->>'ip_address'").count
     end
 
     def custom_page_visits_by_range(start_time, end_time, page_slug)
-      Ahoy::Event.where(name: 'Site visit').where("properties->>'ip_address' is not null").where("properties->>'page_group' = '#{page_slug}'").where(time: start_time..end_time).group("properties->>'ip_address'").count
+      Ahoy::Event.where(name: 'Site visit').where("properties->>'ip_address' is not null").where("properties->>'is_duplicate' is null").where("properties->>'page_group' = '#{page_slug}'").where(time: start_time..end_time).group("properties->>'ip_address'").count
     end
 
     def custom_page_visits(page_slug)
-      Ahoy::Event.where(name: 'Site visit').where("properties->>'ip_address' is not null").where("properties->>'page_group' = '#{page_slug}'").count
+      Ahoy::Event.where(name: 'Site visit').where("properties->>'ip_address' is not null").where("properties->>'is_duplicate' is null").where("properties->>'page_group' = '#{page_slug}'").count
     end
 
     def get_custom_pages_stats(custom_pages)

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -104,7 +104,7 @@ ActiveAdmin.register_page "Dashboard" do
         # Get practice views by month
         @approved_enabled_published_practices.each do |p|
           practice_visits_by_month = []
-          pr_visit_ct = Ahoy::Event.where_props(practice_id: p[:id]).where(time: beg_of_month...end_of_month).count
+          pr_visit_ct = p.date_range_views(beg_of_month, end_of_month)
           practice_visits_by_month << pr_visit_ct
           practice_visits_by_month.each do |visit_count|
             @practice_views_array << [p.id, visit_count]

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -1,5 +1,5 @@
 class PracticesController < ApplicationController
-  include CropperUtils, PracticesHelper, PracticeEditorUtils, EditorSessionUtils
+  include CropperUtils, PracticesHelper, PracticeEditorUtils, EditorSessionUtils, PracticeEditorSessionsHelper
   before_action :set_practice, only: [:show, :edit, :update, :destroy, :highlight, :un_highlight, :feature,
                                       :un_feature, :favorite, :instructions, :overview, :impact, :resources, :documentation,
                                       :departments, :timeline, :risk_and_mitigation, :contact, :checklist, :publication_validation, :adoptions,
@@ -547,10 +547,7 @@ class PracticesController < ApplicationController
     if @current_session.present? && @current_session.user === current_user
       PracticeEditorSession.extend_current_session(@current_session)
     else
-      msg = "You cannot edit this practice since it is currently being edited by #{@current_session.user.full_name === 'User' ? @current_session.user.email : @current_session.user.full_name}"
-      if @current_session.user.roles.find_by(name: 'admin').present?
-        msg += " (Site Admin)"
-      end
+      msg = "You cannot edit this practice since it is currently being edited by #{session_username(@current_session)}"
       render :js => "window.location = '#{practice_metrics_path(@practice)}'"
       flash[:warning] = msg
     end
@@ -592,10 +589,7 @@ class PracticesController < ApplicationController
       PracticeEditorSession.lock_practice_for_user(cur_user_id, @practice.id)
     else
       if @current_session.user != current_user
-        msg = "You cannot edit this practice since it is currently being edited by #{@current_session.user.full_name === 'User' ? @current_session.user.email : @current_session.user.full_name}"
-        if @current_session.user.roles.find_by(name: 'admin').present?
-          msg += " (Site Admin)"
-        end
+        msg = "You cannot edit this practice since it is currently being edited by #{session_username(@current_session)}"
         respond_to do |format|
           flash[:warning] = msg
           format.html { redirect_to practice_metrics_path(@practice), warning: msg }

--- a/app/controllers/practices_controller.rb
+++ b/app/controllers/practices_controller.rb
@@ -38,7 +38,6 @@ class PracticesController < ApplicationController
   # GET /practices/1
   # GET /practices/1.json
   def show
-    ahoy.track "Practice show", {practice_id: @practice.id} if current_user.present?
     # This allows comments thread to show up without the need to click a link
     commontator_thread_show(@practice)
 

--- a/app/helpers/practice_editor_sessions_helper.rb
+++ b/app/helpers/practice_editor_sessions_helper.rb
@@ -1,0 +1,11 @@
+module PracticeEditorSessionsHelper
+  def session_username(session)
+    if session.user.present? && session.user.full_name.present?
+      username = session.user.full_name === 'User' ? session.user.email : session.user.full_name
+      username += " (Site Admin)" if session.user.roles.find_by(name: 'admin').present?
+      username
+    else
+      ''
+    end
+  end
+end

--- a/app/models/practice.rb
+++ b/app/models/practice.rb
@@ -89,7 +89,11 @@ class Practice < ApplicationRecord
 
   # views
   def views
-    Ahoy::Event.where_props(practice_id: id).count
+    Ahoy::Event.where(name: 'Practice show').where_props(practice_id: id).where("properties->>'is_duplicate' is null").count
+  end
+
+  def date_range_views(start_date, end_date)
+    Ahoy::Event.where(name: 'Practice show').where_props(practice_id: id).where("properties->>'is_duplicate' is null").where(time: start_date...end_date).count
   end
 
   def current_month_views
@@ -326,9 +330,6 @@ class Practice < ApplicationRecord
     diffusion_histories.joins(:diffusion_history_statuses).where(diffusion_history_statuses: {status: 'Unsuccessful'}).count
   end
 
-  def date_range_views(start_date, end_date)
-    Ahoy::Event.where_props(practice_id: id).where(time: start_date...end_date).count
-  end
   def favorited_count
     user_practices.where({favorited: true}).count
   end

--- a/app/models/practice_editor_session.rb
+++ b/app/models/practice_editor_session.rb
@@ -18,18 +18,6 @@ class PracticeEditorSession < ApplicationRecord
     PracticeEditorSession.create user_id: user_id, practice_id: practice_id, session_start_time: DateTime.now, session_end_time: nil
   end
 
-  def self.practice_last_updated(practice_id)
-    session = PracticeEditorSession.where(practice_id: practice_id).where.not(session_end_time: nil).order("session_end_time DESC").first
-    return "" if session.blank?
-    lock_user = session.user.full_name === 'User' ? session.user.email : session.user.full_name
-    s_text = "Practice last updated on #{session.session_end_time.strftime("%B %d, %Y")} at #{session.session_end_time.strftime("%I:%M %p")}".gsub(/^0/,'')
-    s_text += " by #{lock_user}"
-    if session.user.roles.find_by(name: 'admin').present?
-      s_text += " (Site Admin)"
-    end
-    s_text
-  end
-
   def self.extend_current_session(session)
     session.session_start_time = DateTime.now
     session.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,7 +117,7 @@ class User < ApplicationRecord
   def full_name
     return 'User' unless last_name || first_name
 
-    "#{first_name} #{last_name}"
+    "#{first_name}#{' ' if last_name && first_name}#{last_name}"
   end
 
   def favorite_practices

--- a/app/views/layouts/_ahoy_event_tracking.js.erb
+++ b/app/views/layouts/_ahoy_event_tracking.js.erb
@@ -35,7 +35,6 @@ function trackVisit(visit, visitor) {
   }
 }
 
-
 document.addEventListener('turbolinks:load', function () {
   var visitProps = <%= raw @visit_properties.to_json %>;
   var visitorProps = <%= raw @visitor_properties.to_json %>;
@@ -44,7 +43,5 @@ document.addEventListener('turbolinks:load', function () {
     if (shouldTrackVisit(visitProps, visitorProps)) {
       trackVisit(visitProps, visitorProps);
     }
-  } else {
-    trackVisit(visitProps, visitorProps);
   }
 });

--- a/app/views/practices/form/_practice_last_updated.html.erb
+++ b/app/views/practices/form/_practice_last_updated.html.erb
@@ -1,8 +1,9 @@
-<% last_updated = PracticeEditorSession.practice_last_updated(@practice.id) %>
-<% unless last_updated.blank? %>
+<% session = PracticeEditorSession.where(practice_id: @practice.id).where.not(session_end_time: nil).last %>
+<% if session.present? %>
   <div class="margin-y-2">
     <div class="text-base">
-      <%= last_updated %>
+      Practice last updated on
+      <%= get_local_date_and_time(session.session_end_time) %> by <%= session_username(session) %>
     </div>
   </div>
 <% end %>

--- a/app/views/practices/show/authenticated/_ahoy_event_tracking.js.erb
+++ b/app/views/practices/show/authenticated/_ahoy_event_tracking.js.erb
@@ -1,0 +1,48 @@
+var PRACTICE_SHOW_KEY = 'practice-show';
+
+function savePracticeShow(visit) {
+  sessionStorage.setItem(PRACTICE_SHOW_KEY, JSON.stringify(visit));
+}
+
+function shouldTrackPracticeShow(currentVisit) {
+  var prevVisit = JSON.parse(sessionStorage.getItem(PRACTICE_SHOW_KEY));
+
+  if (prevVisit) {
+    var prevVisitTime = prevVisit.timestamp;
+    var currentVisitTime = currentVisit.timestamp;
+    var isSameVisit = (currentVisitTime - prevVisitTime) <= 1000;
+    var isSamePractice = currentVisit["practice_id"] === prevVisit["practice_id"];
+    var isSameUser = currentVisit.userId === prevVisit.userId
+
+    // make sure we aren't logging the same exact practice show (difference between visits is <= 1000ms) by same user for the same request
+    // this occurs because of turbolinks reloading the page
+    return !(isSameVisit && isSamePractice && isSameUser);
+  } else {
+    return true;
+  }
+}
+
+function trackPracticeShow(visit) {
+  savePracticeShow(visit);
+  // remove the timestamp and userId key/value from the prevVisit object
+  delete visit.timestamp;
+  delete visit.userId;
+  ahoy.track('Practice show', visit);
+}
+
+
+document.addEventListener('turbolinks:load', function () {
+  var action = "<%= params[:action] %>";
+  // only track on the show action
+  if (action === 'show') {
+    var userId = <%= current_user.id %>;
+    var practiceId = <%= @practice.id %>;
+    // only track if there is a current user and practice
+    if (userId && practiceId) {
+      var practiceShowProps = { "practice_id": practiceId, timestamp: Date.now(), userId: userId };
+      if (shouldTrackPracticeShow(practiceShowProps)) {
+        trackPracticeShow(practiceShowProps);
+      }
+    }
+  }
+});

--- a/app/views/practices/show/authenticated/_ahoy_event_tracking.js.erb
+++ b/app/views/practices/show/authenticated/_ahoy_event_tracking.js.erb
@@ -31,10 +31,12 @@ function trackPracticeShow(visit) {
 }
 
 
-document.addEventListener('turbolinks:load', function () {
+function ahoyEventTrackingFns() {
   var action = "<%= params[:action] %>";
+  var controller = "<%= params[:controller] %>";
+
   // only track on the show action
-  if (action === 'show') {
+  if (action === 'show' && controller === 'practices') {
     var userId = <%= current_user.id %>;
     var practiceId = <%= @practice.id %>;
     // only track if there is a current user and practice
@@ -45,4 +47,6 @@ document.addEventListener('turbolinks:load', function () {
       }
     }
   }
-});
+};
+
+ahoyEventTrackingFns();

--- a/app/views/practices/show/authenticated/_show_authenticated.html.erb
+++ b/app/views/practices/show/authenticated/_show_authenticated.html.erb
@@ -1,8 +1,5 @@
 <% provide :head_tags do %>
   <%= javascript_include_tag 'practice_page', 'data-turbolinks-track': 'reload' %>
-  <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
-    <%= render partial: 'practices/show/authenticated/ahoy_event_tracking', formats: [:js] %>
-  <% end %>
 <% end %>
 
 <section class="usa-section padding-y-0">
@@ -192,3 +189,7 @@
 <% if @practice.origin_story.present? || @practice.va_employees.any? %>
   <%= render partial: 'practices/show/about/about' %>
 <% end %>
+
+<script type="text/javascript">
+  <%= render partial: 'practices/show/authenticated/ahoy_event_tracking.js' %>
+</script>

--- a/app/views/practices/show/authenticated/_show_authenticated.html.erb
+++ b/app/views/practices/show/authenticated/_show_authenticated.html.erb
@@ -1,5 +1,8 @@
 <% provide :head_tags do %>
   <%= javascript_include_tag 'practice_page', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_tag 'data-turbolinks-track': 'reload' do %>
+    <%= render partial: 'practices/show/authenticated/ahoy_event_tracking', formats: [:js] %>
+  <% end %>
 <% end %>
 
 <section class="usa-section padding-y-0">

--- a/spec/helpers/practice_editor_sessions_helper_spec.rb
+++ b/spec/helpers/practice_editor_sessions_helper_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe PracticeEditorSessionsHelper, type: :helper do
+  describe "#session_username" do
+    context "when given a session with an admin user with first and last name" do
+      it "returns the full name and (Site Admin)" do
+        user = User.create!(email: 'test@va.gov', first_name: 'Ash', last_name: 'Ketchum', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+        practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: user)
+        user.add_role(User::USER_ROLES[1].to_sym)
+        session = PracticeEditorSession.create(session_start_time: DateTime.now, practice: practice, user: user)
+        expect(helper.session_username(session)).to eq('Ash Ketchum (Site Admin)')
+      end
+    end
+
+    context "when given a session with an admin user with first and no last name" do
+      it "returns the first name and (Site Admin)" do
+        user = User.create!(email: 'test@va.gov', first_name: 'Ash', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+        practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: user)
+        user.add_role(User::USER_ROLES[1].to_sym)
+        session = PracticeEditorSession.create(session_start_time: DateTime.now, practice: practice, user: user)
+        expect(helper.session_username(session)).to eq('Ash (Site Admin)')
+      end
+    end
+
+    context "when given a session with an admin user with last name and no first name" do
+      it "returns the last name and (Site Admin)" do
+        user = User.create!(email: 'test@va.gov', last_name: 'Ketchum', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+        practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: user)
+        user.add_role(User::USER_ROLES[1].to_sym)
+        session = PracticeEditorSession.create(session_start_time: DateTime.now, practice: practice, user: user)
+        expect(helper.session_username(session)).to eq('Ketchum (Site Admin)')
+      end
+    end
+
+    context "when given a session with an admin user with an email but no name" do
+      it "returns the email and (Site Admin)" do
+        user = User.create!(email: 'test@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+        practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: user)
+        user.add_role(User::USER_ROLES[1].to_sym)
+        session = PracticeEditorSession.create(session_start_time: DateTime.now, practice: practice, user: user)
+        expect(helper.session_username(session)).to eq('test@va.gov (Site Admin)')
+      end
+    end
+
+    context "when given a session with a user with first and last name" do
+      it "returns name" do
+        user = User.create!(email: 'test@va.gov', first_name: 'Ash', last_name: 'Ketchum', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+        practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: user)
+        session = PracticeEditorSession.create(session_start_time: DateTime.now, practice: practice, user: user)
+        expect(helper.session_username(session)).to eq('Ash Ketchum')
+      end
+    end
+
+    context "when given a session with a user with only a first name and no last name" do
+      it "returns the first name" do
+        user = User.create!(email: 'test@va.gov', first_name: 'Ash', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+        practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: user)
+        session = PracticeEditorSession.create(session_start_time: DateTime.now, practice: practice, user: user)
+        expect(helper.session_username(session)).to eq('Ash')
+      end
+    end
+
+    context "when given a session with a user with only a last name and no first name" do
+      it "returns the last name" do
+        user = User.create!(email: 'test@va.gov', last_name: 'Ketchum', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+        practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: user)
+        session = PracticeEditorSession.create(session_start_time: DateTime.now, practice: practice, user: user)
+        expect(helper.session_username(session)).to eq('Ketchum')
+      end
+    end
+
+    context "when given a session with a user with no name" do
+      it "returns email" do
+        user = User.create!(email: 'test@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+        practice = Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: user)
+        session = PracticeEditorSession.create(session_start_time: DateTime.now, practice: practice, user: user)
+        expect(helper.session_username(session)).to eq('test@va.gov')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### JIRA issue link
[DM-2369](https://agile6.atlassian.net/secure/RapidBoard.jspa?rapidView=22&projectKey=DM&modal=detail&selectedIssue=DM-2369)

## Description - what does this code do?
This PR allows for the following:
- not double count "Practice show" visits when clicking on a practice's practice card
- filter site visits by the `is_duplicate` property so we do not count those visits that were corrected by this [script](https://agile6.atlassian.net/browse/DM-2375). (**NOTE**: The way we are currently fetching "Practice show" counts on the metrics page -- we may want to refactor later to use the same queries throughout the codebase--meant we did not need to explicitly filter by the `is_duplicate` property added by this [script](https://agile6.atlassian.net/browse/DM-2374).) We needed to filter by the is_duplicate property when getting practice views on the admin dashboard 
- refactor the "last updated" message so that we use a helper to display the session's username and use the `local_time` gem to display the time

## Testing done - how did you test it/steps on how can another person can test it 
**Practice show double count**
1. Do not log in
2. Click on a practice card from the homepage (highlighted practice's Practice card)
3. Check you ahoy_events table and ensure no "Practice show" count was added when you were not logged in
4. Now, log in as a user
5. Click on a practice card
6. Check you ahoy_events table and ensure only one "Practice show" count was added for that practice
7. Navigate to another practice show page via changing the url
8. Check you ahoy_events table and ensure only one "Practice show" count was added for that practice

**Practice show count**
1. Go to a practice's metrics page and scroll to the leaderboard section
2. Click on the all-time tab
3. Take note of the number of views for the practice leaderboards
4. Now run [this script](https://agile6.atlassian.net/browse/DM-2376) for a certain month and year and take note of how many practices were updated
5. Refresh the practice leaderboards and make sure the amount of views for the practices went down accordingly (NOTE: if the practice is not on the leaderboard but it's count was updated this may not reflect on the leaderboard so keep that in mind)
6. Go to the admin dashboard and ensure the same practice view counts in the "Practice leaderboards" tab

**Site visit count**
1. Go to the admin panel and take note of the number of "Page Views from last month"
2. Run [this script](https://agile6.atlassian.net/browse/DM-2375) for last month and take note of the number updated
3. Refresh the admin panel and the "Page Views from last month" should be a different number that takes into account the number updated in the script

**Last updated message**
1. Go to a practice that had an expired and ended session
2. Check that the last updated message is in localtime and the user who last updated it is displaying correctly
3. Try to edit a practice another editor is editing
4. Make sure the message when you are redirected to the Metrics page is displaying correctly with the username and if they are a Site admin or not

**Updated**
1. Make sure comments show up on the Practice show page
2. Go to practice via practice card, ensure only one "Practice show" visit
3. Now click on a non-practice show page like return to homepage or covid-19 page, there should not be another "Practice show" visit in the DB
4. Navigate to a practice show page via URL and there should only be one "Practice show" visit in the DB

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [X] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs