### PR TITLE
DM-2397: Fix page tracking

### DIFF
--- a/app/views/layouts/_ahoy_event_tracking.js.erb
+++ b/app/views/layouts/_ahoy_event_tracking.js.erb
@@ -17,23 +17,9 @@ function shouldTrackVisit(currentVisit, currentVisitor) {
     var isSameLocation = currentVisit.query === prevVisit.query && currentVisit.action === prevVisit.action && currentVisit.controller === prevVisit.controller;
     var isSameUser = currentVisitor.role === prevVisitor.role && currentVisitor.user === prevVisitor.user;
 
-    var isSamePageGroup;
-    if (currentVisit["page_group"] && prevVisit["page_group"]) {
-      isSamePageGroup = currentVisit["page_group"] === prevVisit["page_group"];
-    } else {
-      isSamePageGroup = false;
-    }
-
-    var isSamePageSlug;
-    if (currentVisit["page_slug"] && prevVisit["page_slug"]) {
-      isSamePageSlug = currentVisit["page_slug"] === prevVisit["page_slug"];
-    } else {
-      isSamePageSlug = false;
-    }
-
     // make sure we aren't logging the same exact visit (difference between visits is <= 1000ms) by same user for the same request
     // this occurs because of turbolinks reloading the page
-    return !(isSameVisit && isSameLocation && isSameUser && isSamePageGroup && isSamePageSlug);
+    return !(isSameVisit && isSameLocation && isSameUser);
   } else {
     return true;
   }


### PR DESCRIPTION
### JIRA issue link


## Description - what does this code do?
This PR ensures the previous page isn't tracked when clicking on internal links.

## Testing done - how did you test it/steps on how can another person can test it 
Prereq:
1. Make sure your local COVID-19 page has a `PageSubpageHyperlinkComponent` that links to a custom subpage like `/covid-19/telehealth`
Testing Steps
1. Log in as a user.
2. Click on the "COVID-19" homepage banner link.
3. Check in the admin dashboard custom page traffic that only the view count for `covid-19` increased by 1
4. Now click on the subpage hyperlink like `/covid-19/telehealth`
5. Check in the admin dashboard custom page traffic that only the view count for `covid-19/telehealth` went up by 1 and that `covid-19` view count remains the same as step 3
6. Now go to a practice page
7. Open your `ahoy_events` table and ensure only the visit for the show page was tracked
8. Click on "Edit practice"
9. Open your `ahoy_events` table and ensure only the visit for the metrics page was tracked
10. Click on a particular edit page of your choice (e.g. Adoptions, Introduction)
11. Open your `ahoy_events` table and ensure only the visit for that edit page was tracked and not the previous page

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Unit tests written (if applicable)
- [ ] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating JIRA issue
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs