### PR TITLE
DM-2469: Add URLs to PageImageComponents

### DIFF
--- a/app/models/concerns/external_url_validator.rb
+++ b/app/models/concerns/external_url_validator.rb
@@ -1,0 +1,15 @@
+class ExternalUrlValidator < ActiveModel::Validator
+  def validate(record)
+    url = record.url
+    begin
+      # source for regex: https://stackoverflow.com/questions/34561083/how-to-validate-url-in-rails-model
+      match = url.match(/^(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/ix)
+      uri = URI.parse(url)
+      unless (uri.kind_of?(URI::HTTP) || uri.kind_of?(URI::HTTPS)) && match.present?
+        raise StandardError.new 'Not a valid external URL'
+      end
+    rescue => e
+      record.errors.add(:url, e.message)
+    end
+  end
+end

--- a/app/models/page_image_component.rb
+++ b/app/models/page_image_component.rb
@@ -4,6 +4,8 @@ class PageImageComponent < ApplicationRecord
 
   validates :page_image, :alt_text, presence: true
   validates_attachment_content_type :page_image, :content_type => ["image/jpg", "image/jpeg", "image/png"]
+  validates_with InternalUrlValidator, on: [:create, :update], if: Proc.new { |page_component| page_component.url.present? && page_component.url.chars.first === '/' }
+  validates_with ExternalUrlValidator, on: [:create, :update], if: Proc.new { |page_component| page_component.url.present? && page_component.url.chars.first != '/' }
 
   def page_image_s3_presigned_url(style = nil)
     object_presigned_url(page_image, style)

--- a/app/views/active_admin/resource/_page_image_component_form.html.arb
+++ b/app/views/active_admin/resource/_page_image_component_form.html.arb
@@ -31,14 +31,21 @@ html = Arbre::Context.new do
           input value: component&.page_image || nil, type: 'file', required: 'required', accept: '.jpg, .jpeg, .png',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_page_image",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][page_image]"
-          para 'Alternate text that gets rendered in case the image cannot load.', class: 'inline-hints'
+          para 'File types allowed: jpg, png. Max file size: 25MB', class: 'inline-hints'
         end
         li class: 'string input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_alt_text_input" do
           label 'Alternative Text', for: "page_page_components_attributes_#{placeholder}_component_attributes_alt_text", class: 'label'
           input value: component&.alt_text || nil, type: 'text', required: 'required',
                 id: "page_page_components_attributes_#{placeholder}_component_attributes_alt_text",
                 name: "page[page_components_attributes][#{placeholder}][component_attributes][alt_text]"
-          para 'File types allowed: jpg, png. Max file size: 25MB', class: 'inline-hints'
+          para 'Alternate text that gets rendered in case the image cannot load.', class: 'inline-hints'
+        end
+        li class: 'url input required stringish', id: "page_page_components_attributes_#{placeholder}_component_attributes_url_input" do
+          label 'Url', for: "page_page_components_attributes_#{placeholder}_component_attributes_url", class: 'label'
+          input value: component&.url || nil, type: 'text',
+                id: "page_page_components_attributes_#{placeholder}_component_attributes_url",
+                name: "page[page_components_attributes][#{placeholder}][component_attributes][url]"
+          para 'Enter a URL suffix to any internal page of the marketplace (Ex: "/practices/vione", "/partners", "/covid-19/telehealth" or a complete external URL (Ex. https://www.va.gov/) that you would like the image to link to', class: 'inline-hints'
         end
       end
     end

--- a/app/views/page/_page_image.html.erb
+++ b/app/views/page/_page_image.html.erb
@@ -1,0 +1,1 @@
+<img class="width-auto maxh-15rem" src="<%= component.page_image_s3_presigned_url %>" alt="<%= component.alt_text %>"/>

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -97,10 +97,10 @@
           <div class="grid-row margin-bottom-3 <%= get_grid_alignment_css_class(component.alignment.downcase) %> <%= page_narrow_classes %>">
             <% if component.url.present? %>
               <a href="<%= component.url %>" target="<%= component.url.chars.first === '/' ? '' : '_blank' %>" title="Go to <%= component.url %>">
-                <img class="width-auto maxh-15rem" src="<%= component.page_image_s3_presigned_url %>" alt="<%= component.alt_text %>"/>
+                <%= render partial: "page/page_image", locals: { component: component } %>
               </a>
             <% else %>
-              <img class="width-auto maxh-15rem" src="<%= component.page_image_s3_presigned_url %>" alt="<%= component.alt_text %>"/>
+                <%= render partial: "page/page_image", locals: { component: component } %>
             <% end %>
           </div>
 

--- a/app/views/page/show.html.erb
+++ b/app/views/page/show.html.erb
@@ -95,7 +95,13 @@
         <%# Image %>
         <% when 'PageImageComponent' %>
           <div class="grid-row margin-bottom-3 <%= get_grid_alignment_css_class(component.alignment.downcase) %> <%= page_narrow_classes %>">
-            <img class="width-auto maxh-15rem" src="<%= component.page_image_s3_presigned_url %>" alt="<%= component.alt_text %>"/>
+            <% if component.url.present? %>
+              <a href="<%= component.url %>" target="<%= component.url.chars.first === '/' ? '' : '_blank' %>" title="Go to <%= component.url %>">
+                <img class="width-auto maxh-15rem" src="<%= component.page_image_s3_presigned_url %>" alt="<%= component.alt_text %>"/>
+              </a>
+            <% else %>
+              <img class="width-auto maxh-15rem" src="<%= component.page_image_s3_presigned_url %>" alt="<%= component.alt_text %>"/>
+            <% end %>
           </div>
 
         <%# Practice List %>

--- a/db/migrate/20210406142716_add_url_to_page_image_component.rb
+++ b/db/migrate/20210406142716_add_url_to_page_image_component.rb
@@ -1,0 +1,5 @@
+class AddUrlToPageImageComponent < ActiveRecord::Migration[5.2]
+  def change
+    add_column :page_image_components, :url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_27_210024) do
+ActiveRecord::Schema.define(version: 2021_04_06_142716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -582,6 +582,7 @@ ActiveRecord::Schema.define(version: 2021_01_27_210024) do
     t.string "page_image_content_type"
     t.integer "page_image_file_size"
     t.datetime "page_image_updated_at"
+    t.string "url"
     t.index ["page_component_id"], name: "index_page_image_components_on_page_component_id"
   end
 
@@ -955,8 +956,8 @@ ActiveRecord::Schema.define(version: 2021_01_27_210024) do
     t.string "overview_solution"
     t.string "overview_results"
     t.integer "maturity_level"
-    t.datetime "practice_pages_updated"
     t.datetime "date_published"
+    t.datetime "practice_pages_updated"
     t.string "highlight_title"
     t.string "highlight_body"
     t.index ["slug"], name: "index_practices_on_slug", unique: true

--- a/spec/features/pages/show_page_spec.rb
+++ b/spec/features/pages/show_page_spec.rb
@@ -17,6 +17,9 @@ describe 'Page Builder - Show', type: :feature do
     image_path = File.join(Rails.root, '/spec/assets/charmander.png')
     image_file = File.new(image_path)
     image_component = PageImageComponent.create(alignment: 'right', alt_text: 'best pokemon ever', page_image: image_file)
+    image_path_2 = File.join(Rails.root, '/spec/assets/SpongeBob.png')
+    image_file_2 = File.new(image_path_2)
+    image_component_2 = PageImageComponent.create(alignment: 'center', alt_text: 'image with link', page_image: image_file_2, url: 'https://va.gov')
     cta_component = PageCtaComponent.create(url: 'https://www.google.com', button_text:'Search now', cta_text: 'Curious about programming languages?')
     youtube_video_component = PageYouTubePlayerComponent.create(url: 'https://www.youtube.com/watch?v=C0DPdy98e4c', caption: 'Test Video')
     downloadable_file = File.new(File.join(Rails.root, '/spec/assets/dummy.pdf'))
@@ -24,6 +27,7 @@ describe 'Page Builder - Show', type: :feature do
     PageComponent.create(page: page, component: practice_list_component, created_at: Time.now)
     PageComponent.create(page: page, component: subpage_hyperlink_component, created_at: Time.now)
     PageComponent.create(page: page, component: image_component, created_at: Time.now)
+    PageComponent.create(page: page, component: image_component_2, created_at: Time.now)
     PageComponent.create(page: page, component: cta_component, created_at: Time.now)
     PageComponent.create(page: page, component: youtube_video_component, created_at: Time.now)
     PageComponent.create(page: page, component: downloadable_file_component, created_at: Time.now)
@@ -52,6 +56,15 @@ describe 'Page Builder - Show', type: :feature do
   it 'Should display the page image' do
     expect(page).to have_css("img[src*='charmander.png']")
     page.should have_css('.justify-end')
+  end
+
+  it 'should display the page image with a url' do
+    expect(page).to have_css("img[src*='SpongeBob.png']")
+    page.should have_css('.justify-center')
+
+    # get the parent element of the image's URL
+    link = page.find("img[src*='SpongeBob.png']").find(:xpath, '..')
+    link[:href].should == "https://va.gov/"
   end
 
   it 'Should display the call to action' do

--- a/spec/models/concerns/external_url_validator_spec.rb
+++ b/spec/models/concerns/external_url_validator_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe ExternalUrlValidator do
+  describe 'external url validations' do
+    before do
+      user = User.create!(email: 'test@va.gov', password: 'Password123', password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+      Practice.create!(name: 'A public practice', slug: 'a-public-practice', approved: true, published: true, tagline: 'Test tagline', user: user)
+      page_group = PageGroup.create(name: 'programming', slug: 'programming', description: 'Pages about programming go in this group.')
+      Page.create(page_group: page_group, title: 'ruby', description: 'what a gem', slug: 'ruby-rocks', created_at: Time.now)
+      @attachment = File.new("#{Rails.root}/spec/assets/acceptable_img.jpg")
+    end
+
+    context "given a URL with no protocol (e.g. http, https)" do
+      it 'should add an error message' do
+        component = PageImageComponent.new(page_image: @attachment, alt_text: 'alt image', url: 'www.fake-url.com')
+        component.valid?
+        expect(component.errors[:url][0]).to eq("Not a valid external URL")
+      end
+    end
+
+    context 'given a URL with no domain extension' do
+      it 'should add an error message' do
+        component = PageImageComponent.new(page_image: @attachment, alt_text: 'alt image', url: 'https://www.google')
+        component.valid?
+        expect(component.errors[:url][0]).to eq("Not a valid external URL")
+      end
+    end
+
+    context 'given a URL with http' do
+      it 'should add an error message' do
+        component = PageImageComponent.new(page_image: @attachment, alt_text: 'alt image', url: 'http://www.google.com')
+        component.valid?
+        expect(component.errors[:url][0]).to eq(nil)
+      end
+    end
+
+    context 'given a URL with https' do
+      it 'should have no errors' do
+        component = PageImageComponent.new(page_image: @attachment, alt_text: 'alt image', url: 'https://www.google.com')
+        component.valid?
+        expect(component.errors[:url][0]).to eq(nil)
+      end
+    end
+
+    context 'given an malformed URL' do
+      it 'should have no errors' do
+        component = PageImageComponent.new(page_image: @attachment, alt_text: 'alt image', url: 'https//wwwgooglecom')
+        component.valid?
+        expect(component.errors[:url]).to eq(["Not a valid external URL"])
+      end
+    end
+  end
+end

--- a/spec/models/concerns/external_url_validator_spec.rb
+++ b/spec/models/concerns/external_url_validator_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe ExternalUrlValidator do
     end
 
     context 'given a URL with http' do
-      it 'should add an error message' do
+      it 'should have no errors' do
         component = PageImageComponent.new(page_image: @attachment, alt_text: 'alt image', url: 'http://www.google.com')
         component.valid?
         expect(component.errors[:url][0]).to eq(nil)
@@ -43,7 +43,7 @@ RSpec.describe ExternalUrlValidator do
     end
 
     context 'given an malformed URL' do
-      it 'should have no errors' do
+      it 'should add an error message' do
         component = PageImageComponent.new(page_image: @attachment, alt_text: 'alt image', url: 'https//wwwgooglecom')
         component.valid?
         expect(component.errors[:url]).to eq(["Not a valid external URL"])


### PR DESCRIPTION
### JIRA issue link
[DM-2469](https://agile6.atlassian.net/browse/DM-2469)

## Description - what does this code do?
This PR adds the ability to add a link to a `PageImageComponent`. The link can be an internal or external one.

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin.
2. Go to `/admin/pages` and edit a page.
3. Add an image component without a URL.
4. Ensure the show page of the custom displays the image correctly and it has no URL.
5. Go to `/admin/pages` and edit the same page.
6. Add/Change the image component to include an internal URL.
7. Ensure the show page of the custom displays the image correctly and when you click it it leads to the internal page you designated.
8. Go to `/admin/pages` and edit the same page.
9. Add/Change an image component to include an external URL.
10. Ensure the show page of the custom displays the image correctly and when you click it it leads to the external page you designated.
11.  Go to `/admin/pages` and edit the same page.
12. Try different URLs (internal and external) that are malformed to ensure the page does not save.

## Screenshots, Gifs, Videos from application (if applicable)


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [X] Picture can be a hyperlink
- [X] Picture is a hyperlink to outside of marketplace page
- [X] Header photo needs to be hyperlink 

## Definition of done
- [X] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs