### PR TITLE
DM-2480: Add "Vaccine Acceptance" to nav header

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -19,6 +19,11 @@
             <span>Shark Tank</span>
           </a>
         </li>
+        <li class="usa-nav__primary-item">
+          <a class="usa-nav__link <%= 'usa-current' if request.fullpath == '/covid-19/vaccine-acceptance' %>" href="/covid-19/vaccine-acceptance">
+            <span>Vaccine Acceptance</span>
+          </a>
+        </li>
         <!-- WIP: UNCOMMENT WHEN ADDING VISN & VAMC FEATURE WORK
         <li class="usa-nav__primary-item">
           <button class="usa-accordion__button usa-nav__link" aria-expanded="false" aria-controls="dm-navbar-directories">

--- a/spec/features/shared/header_spec.rb
+++ b/spec/features/shared/header_spec.rb
@@ -8,6 +8,8 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
     login_as(@admin, :scope => :user, :run_callbacks => false)
     page_group = PageGroup.create(name: 'competitions', slug: 'competitions', description: 'competitions page')
     Page.create(page_group: page_group, title: 'Shark Tank', description: 'Shark Tank page', slug: 'shark-tank', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
+    page_group_2 = PageGroup.create(name: 'covid-19', slug: 'covid-19', description: 'covid-19 page')
+    Page.create(page_group: page_group_2, title: 'Vaccine Acceptance', description: 'Vaccine Acceptance page', slug: 'vaccine-acceptance', has_chrome_warning_banner: true, created_at: Time.now, published: Time.now)
     visit practice_overview_path(@practice)
   end
 
@@ -32,6 +34,8 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
         expect(page).to have_link(href: '/diffusion-map')
         expect(page).to have_content('Shark Tank')
         expect(page).to have_link(href: '/competitions/shark-tank')
+        expect(page).to have_content('Vaccine Acceptance')
+        expect(page).to have_link(href: '/covid-19/vaccine-acceptance')
         expect(page).to have_content('Your profile')
       end
     end
@@ -47,6 +51,13 @@ describe 'Diffusion Marketplace header', type: :feature, js: true do
       it 'should redirect to shark tank page' do
         click_on 'Shark Tank'
         expect(page).to have_current_path('/competitions/shark-tank')
+      end
+    end
+
+    context 'clicking on the Vaccine Acceptance link' do
+      it 'should redirect to covid-19 Vaccine Acceptance page' do
+        click_on 'Vaccine Acceptance'
+        expect(page).to have_current_path('/covid-19/vaccine-acceptance')
       end
     end
 


### PR DESCRIPTION
### JIRA issue link
[DM-2480](https://agile6.atlassian.net/browse/DM-2480)

## Description - what does this code do?
This PR adds "Vaccine Acceptance" nav link to the header

## Testing done - how did you test it/steps on how can another person can test it 
PREREQ:
1. Add and publish page to the "covid-19" page group called "vaccine-acceptance"

TESTING
1. Log in as a user
2. In any page you should see the, "Vaccine Acceptance" link
3. Clicking it should redirect you to the page and the breadcrumbs should look good

## Screenshots, Gifs, Videos from application (if applicable)
Desktop - Hover over link
<img width="1665" alt="Screen Shot 2021-04-09 at 1 45 28 PM" src="https://user-images.githubusercontent.com/20211771/114226943-edfe8c80-9939-11eb-8e93-a9655d3cc5a8.png">

Mobile 
<img width="452" alt="Screen Shot 2021-04-09 at 1 45 36 PM" src="https://user-images.githubusercontent.com/20211771/114226956-f35bd700-9939-11eb-8fb8-04bef8128624.png">

## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [X] Build new header item
- [X] Exact verbiage “Vaccine Acceptance”
- [X] Vaccine Acceptance is a link to https://marketplace.va.gov/covid-19/vaccine-acceptance (Please double check this because I’m writing it from memory) 
- [X] Put it in the middle of the links (order L to R: ST, Vaccine, Diffusion Map)
- [ ] Release Friday afternoon 4/9/21

## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs