### PR TITLE
DM-2466: Add Visn Liaison CRUD to active admin

### DIFF
--- a/app/admin/visn_liasons.rb
+++ b/app/admin/visn_liasons.rb
@@ -1,0 +1,133 @@
+ActiveAdmin.register VisnLiaison do
+  batch_action :destroy, false
+
+  filter :first_name
+  filter :last_name
+  filter :email
+  filter :description
+  filter :related_terms
+
+  index do
+    id_column
+    column :first_name
+    column :last_name
+    column :email
+    column :primary
+    column('VISN number', sortable: :visn_id) { |visn_liaison| visn_liaison.visn[:number] }
+
+    actions do |visn_liaison|
+      visn_liaison_is_primary = visn_liaison[:primary] ? "Make Secondary" : "Make Primary"
+      link_to visn_liaison_is_primary, set_primary_admin_visn_liaison_path(visn_liaison), method: :post
+    end
+  end
+
+  member_action :set_primary, method: :post do
+    resource.primary = !resource.primary
+    can_save = set_can_save(resource)
+    message = set_primary_error_msg(resource)
+    resource.save if can_save
+    if can_save
+      redirect_back fallback_location: root_path, notice: message
+    else
+      redirect_back fallback_location: root_path, flash: { error: message }
+    end
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :first_name
+      row :last_name
+      row :email
+      row :primary
+      row('VISN number') { |visn_liaison| visn_liaison.visn[:number] }
+    end
+  end
+
+  form do |f|
+    f.inputs do
+      f.input :first_name
+      f.input :last_name
+      f.input :email
+      f.input :primary
+      f.input :visn, as: :select, multiple: false, collection: Visn.all.order(number: :asc).map {|visn| ["VISN #{visn.number} - #{visn.name}", visn.id]}, input_html: { value: object[:visn_id] }
+    end
+    f.actions
+  end
+
+  controller do
+    def update
+      create_or_update_visn_liaison(params)
+    end
+
+    def create
+      create_or_update_visn_liaison(params)
+    end
+
+    def create_or_update_visn_liaison(params)
+      is_update = params[:_method] === 'patch'
+      vl_id = params[:id] if is_update
+      visn_liaison_params = set_visn_liaison_params(params)
+      visn_liaison_params_with_id = is_update ? visn_liaison_params.merge({id: vl_id}) : visn_liaison_params
+      can_save = set_can_save(visn_liaison_params_with_id)
+      message = can_save ? "VISN liaison was successfully #{is_update ? 'updated' : 'created'}." : "There was an error #{is_update ? 'updating' : 'creating'} your VISN liaison: #{set_primary_error_msg(visn_liaison_params_with_id)}"
+
+      if is_update
+        saved_resource = resource.update_attributes(visn_liaison_params) if can_save
+      else
+        saved_resource = VisnLiaison.create!(visn_liaison_params) if can_save
+      end
+
+      respond_to do |format|
+        if saved_resource
+          if is_update
+            format.html { redirect_to admin_visn_liaison_path(id: vl_id), notice: message }
+          else
+            format.html { redirect_to new_admin_visn_liaison_path,  notice: message }
+          end
+        else
+          if is_update
+            format.html { redirect_to edit_admin_visn_liaison_path(id: vl_id), flash: { error: message }}
+          else
+            format.html { redirect_to new_admin_visn_liaison_path, flash: { error: message }}
+          end
+        end
+      end
+    end
+
+    private
+
+    def set_visn_liaison_params(params)
+      vl = params[:visn_liaison]
+      return { first_name: vl[:first_name] || '', last_name: vl[:last_name] || '', email: vl[:email] || '', visn_id: vl[:visn_id].to_i, primary: vl[:primary] === '1' }
+    end
+
+    def visn_liaison_ct(visn_liaison)
+      query = VisnLiaison.where(visn_id: visn_liaison[:visn_id], primary: true)
+      query.where.not(id: visn_liaison[:id]) if visn_liaison[:id].present?
+      return query.size
+    end
+
+    def set_can_save(visn_liaison)
+      can_save = true
+      if visn_liaison[:primary]
+        can_save = visn_liaison_ct(visn_liaison) === 0
+      end
+      return can_save
+    end
+
+    def set_primary_error_msg(visn_liaison)
+      visn = Visn.find(visn_liaison[:visn_id])
+      visn_name = "VISN #{visn[:number]} - #{visn[:name]}"
+      message = "VISN liaison, #{visn_liaison[:first_name]} #{visn_liaison[:last_name]}, has been made a secondary contact of #{visn_name}."
+      if visn_liaison[:primary]
+        if visn_liaison_ct(visn_liaison) === 0
+          message = "VISN liaison, #{visn_liaison[:first_name]} #{visn_liaison[:last_name]}, has been made a primary contact of #{visn_name}."
+        else
+          message = "There can be only one primary contact for #{visn_name}."
+        end
+      end
+      return message
+    end
+  end
+end

--- a/app/views/visns/show.html.erb
+++ b/app/views/visns/show.html.erb
@@ -6,7 +6,7 @@
   <section id="visn-introduction" class="margin-bottom-3 margin-top-10">
     <h1 class="font-sans-2xl line-height-46px x0-top">VISN <%= @visn.number %>: <%= @visn.name %></h1>
     <div class="grid-row grid-gap-3">
-      <div class="grid-col-6 line-height-26">
+      <div class="<%= @primary_visn_liaison.present? ? 'grid-col-6' : 'grid-col-12' %> line-height-26">
         <p class="margin-bottom-3">
           <%
             visn_facilities_count = @visn.va_facilities.count
@@ -20,14 +20,16 @@
         </p>
         <%= link_to 'Jump to list of VA facilities', va_facilities_path, class: 'dm-external-link' %>
       </div>
-      <div class="grid-col-6 ">
+      <% if @primary_visn_liaison.present? %>
+        <div class="grid-col-6">
           <div class="visn-liaison-info padding-3 line-height-26 bg-base-lightest">
             <p class="text-bold margin-bottom-2">VISN Marketplace Liaison</p>
             <p class="margin-bottom-2"><%= @primary_visn_liaison.first_name %> <%= @primary_visn_liaison.last_name %></p>
             <% primary_liaison_email = @primary_visn_liaison.email %>
             <p><%= mail_to primary_liaison_email, primary_liaison_email, class: 'visn-liaison-email' %></p>
           </div>
-      </div>
+        </div>
+      <% end %>
     </div>
   </section>
   <%= render partial: 'visns/maps/show_map' %>

--- a/spec/features/admin/admin_visn_liaisons_spec.rb
+++ b/spec/features/admin/admin_visn_liaisons_spec.rb
@@ -1,0 +1,113 @@
+require 'rails_helper'
+
+describe 'Admin VISN Liaisons Tab', type: :feature do
+  before do
+    @admin = User.create!(email: 'admin-test39127129@va.gov', password: 'Password123',
+                          password_confirmation: 'Password123', skip_va_validation: true, confirmed_at: Time.now, accepted_terms: true)
+    @admin.add_role(:admin)
+    @visn = Visn.create!(name: 'Test VISN', number: 2)
+    @visn_2 = Visn.create!(name: 'Desert VISN', number: 3)
+    @visn_liaison = VisnLiaison.create!(first_name: 'Ash', last_name: 'Ketchum', email: 'ash-ketchum1231243@va.gov', primary: true, visn_id: @visn[:id])
+    @visn_liaison_2 = VisnLiaison.create!(first_name: 'John', last_name: 'Smith', email:'john-smith139023@va.gov', primary: false, visn_id: @visn[:id])
+    login_as(@admin, scope: :user, run_callbacks: false)
+    visit '/admin'
+    click_link 'Visn Liaisons'
+  end
+
+  it 'should show all VISN liaisons and all actions' do
+    within(:css, 'thead') do
+      expect(page).to have_content("Id")
+      expect(page).to have_content("First Name")
+      expect(page).to have_content("Last Name")
+      expect(page).to have_content("Email")
+      expect(page).to have_content("Primary")
+      expect(page).to have_content("VISN number")
+    end
+
+    within(:css, 'tbody') do
+      expect(page).to have_content('Ash')
+      expect(page).to have_content('Ketchum')
+      expect(page).to have_content('ash-ketchum1231243@va.gov')
+      expect(page).to have_content('John')
+      expect(page).to have_content('Smith')
+      expect(page).to have_content('john-smith139023@va.gov')
+      expect(page).to have_content('YES')
+      expect(page).to have_content('NO')
+      expect(page).to have_content('2')
+      expect(page).to have_link('View')
+      expect(page).to have_link('Edit')
+      expect(page).to have_link('Delete')
+      expect(page).to have_link('Make Secondary')
+      expect(page).to have_link('Make Primary')
+    end
+  end
+
+  it "should allow toggling of a VISN liaison\'s primary status" do
+    click_link('Make Primary')
+    expect(page).to have_content('There can be only one primary contact for VISN 2 - Test VISN.')
+    click_link('Make Secondary')
+    expect(page).to have_content('VISN liaison, Ash Ketchum, has been made a secondary contact of VISN 2 - Test VISN.')
+    find("a[href='/admin/visn_liaisons/#{@visn_liaison[:id]}/set_primary']").click
+    expect(page).to have_content('VISN liaison, Ash Ketchum, has been made a primary contact of VISN 2 - Test VISN.')
+  end
+
+  it 'should allow creating a new VISN liaison' do
+    click_link 'New Visn Liaison'
+    fill_form
+    select('VISN 2 - Test VISN', from: 'visn_liaison_visn_id')
+    click_on('Create Visn liaison')
+    fill_form
+    select('VISN 3 - Desert VISN', from: 'visn_liaison_visn_id')
+    click_on('Create Visn liaison')
+    expect(page).to have_current_path(new_admin_visn_liaison_path)
+    expect(page).to have_content('VISN liaison was successfully created.')
+    find_all("a[href='/admin/visn_liaisons']").first.click
+    find_all(".view_link").first.click
+    check_for_liaison_update
+  end
+
+  it 'should allow editing a VISN liaison' do
+    find("a[href='/admin/visn_liaisons/#{@visn_liaison_2[:id]}/edit']").click
+    expect(page).to have_field('First name', with: 'John')
+    expect(page).to have_field('Last name', with: 'Smith')
+    expect(page).to have_field('Email', with: 'john-smith139023@va.gov')
+    expect(page).to have_select('visn_liaison_visn_id', selected: 'VISN 2 - Test VISN')
+    expect(find_all("input[name='visn_liaison[primary]']", visible: false).first.value).to eq('0')
+    fill_form
+    click_on('Update Visn liaison')
+    expect(page).to have_content('There can be only one primary contact for VISN 2 - Test VISN.')
+    fill_form
+    select('VISN 3 - Desert VISN', from: 'visn_liaison_visn_id')
+    click_on('Update Visn liaison')
+    find_all("a[href='/admin/visn_liaisons']").first.click
+    find_all(".view_link").first.click
+    check_for_liaison_update
+  end
+
+  it 'should allow deleting a VISN liaison' do
+    expect(page).to have_content('John')
+    expect(page).to have_content('Smith')
+    expect(page).to have_content('john-smith139023@va.gov')
+    find_all(".delete_link").first.click
+    page.driver.browser.switch_to.alert.accept
+    expect(page).to have_content('Visn liaison was successfully destroyed.')
+    expect(page).to have_no_content('John')
+    expect(page).to have_no_content('Smith')
+    expect(page).to have_no_content('john-smith139023@va.gov')
+  end
+
+  def check_for_liaison_update
+    expect(page).to have_content('Test First Name')
+    expect(page).to have_content('Test Last Name')
+    expect(page).to have_content('test-email239012309@va.gov')
+    expect(page).to have_content('YES')
+    expect(page).to have_content('3')
+  end
+
+  def fill_form
+    fill_in('visn_liaison_first_name', with: 'Test First Name')
+    fill_in('visn_liaison_last_name', with: 'Test Last Name')
+    fill_in('visn_liaison_email', with: 'test-email239012309@va.gov')
+    find(:css, "#visn_liaison_primary").set(true)
+  end
+end


### PR DESCRIPTION
### JIRA issue link
[DM-2466](https://agile6.atlassian.net/browse/DM-2466)

## Description - what does this code do?
This PR adds the "Visn Liaison" tab to the admin dashboard. This PR adds the ability to perform CRUD operations for a `VisnLiaison`.

## Testing done - how did you test it/steps on how can another person can test it 
1. Log in as an admin and navigate to `/admin/visn_liaisons`
2. You should be able to add a new VISN liaison as well as edit and delete them
3. When you try to create or edit another user and set them as a "Primary" contact for a VISN that already has a primary contact that you see an error
4. You should be able to "Make Secondary" any VISN liaison
5. Check a specific VISN page with only "Secondary" VISN liaisons and make sure you do not see a VISN Liaison section

## Screenshots, Gifs, Videos from application (if applicable)
<img width="1856" alt="Screen Shot 2021-04-15 at 1 20 02 PM" src="https://user-images.githubusercontent.com/20211771/114935782-38cc4880-9e01-11eb-8b5f-7f3dba5f9817.png">


## Link to mock-ups/mock ups (image file if you have it) (if applicable)


## Acceptance criteria
- [X] Add “VISN Liaisons” Tab
- [X] Make list configurable in active admin
- [X] Have the ability to add name and email address to different VISNs
- [X] Display name and email address for each
- [X] Add Primary and secondary with only primary displaying
- [X] Show which VISN liaison belongs to
- [X] Ability to check who is displayed

## Definition of done
- [ ] Unit tests written (if applicable)
- [X] e2e/accessibility tests written (if applicable)
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [X] A link has been provided to the originating JIRA issue
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs